### PR TITLE
unify deprecations

### DIFF
--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/BackupRestore.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/BackupRestore.java
@@ -2,9 +2,8 @@ package org.wildfly.extras.creaper.commands.foundation.offline;
 
 import org.wildfly.extras.creaper.core.offline.OfflineCommand;
 
-/**
- * @deprecated Use {@link ConfigurationFileBackup}.
- */
+/** @deprecated use {@link ConfigurationFileBackup} instead, this will be removed before 1.0 */
+@Deprecated
 public final class BackupRestore {
     private final ConfigurationFileBackup delegate = new ConfigurationFileBackup();
 

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/XmlTransform.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/XmlTransform.java
@@ -7,7 +7,8 @@ import org.wildfly.extras.creaper.core.offline.OfflineCommandContext;
 import java.io.IOException;
 import java.util.Map;
 
-/** @deprecated use {@link GroovyXmlTransform} */
+/** @deprecated use {@link GroovyXmlTransform} instead, this will be removed before 1.0 */
+@Deprecated
 public final class XmlTransform implements OfflineCommand {
     private GroovyXmlTransform.Builder builder;
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineCommandContext.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineCommandContext.java
@@ -10,6 +10,7 @@ public final class OfflineCommandContext {
     public final ManagementVersion serverVersion;
     public final File configurationFile; // same as client.options().configurationFile
 
+    /** @deprecated use {@link #serverVersion} instead, this will be removed before 1.0 */
     @Deprecated
     public final ManagementVersion currentVersion;
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineOptions.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineOptions.java
@@ -18,8 +18,10 @@ public final class OfflineOptions {
     public String defaultProfile;
     public String defaultHost;
     /** @deprecated use {@code defaulProfile} instead, this will be removed before 1.0 */
+    @Deprecated
     public final String domainProfile;
     /** @deprecated use {@code defaulhost} instead, this will be removed before 1.0 */
+    @Deprecated
     public final String domainHost;
 
     private final File configurationDirectory; // can be null if configurationFile is specified directly

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/ModelNodeResult.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/ModelNodeResult.java
@@ -27,7 +27,8 @@ import java.util.List;
  * <p>Other than that, work with {@code ModelNodeResult} just like with a {@code ModelNode}.</p>
  */
 public class ModelNodeResult extends ModelNode {
-    /** @deprecated not supposed to be called directly, only for Externalizable */
+    /** @deprecated not supposed to be called directly, only for {@code Externalizable} */
+    @Deprecated
     public ModelNodeResult() {}
 
     public ModelNodeResult(ModelNode original) {

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineCommandContext.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineCommandContext.java
@@ -7,6 +7,7 @@ public final class OnlineCommandContext {
     public final OnlineOptions options; // same as client.options()
     public final ManagementVersion serverVersion; // same as client.serverVersion()
 
+    /** @deprecated use {@link #serverVersion} instead, this will be removed before 1.0 */
     @Deprecated
     public final ManagementVersion currentVersion;
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
@@ -32,8 +32,10 @@ public final class OnlineOptions {
     public String defaultProfile;
     public String defaultHost;
     /** @deprecated use {@code defaulProfile} instead, this will be removed before 1.0 */
+    @Deprecated
     public final String domainProfile;
     /** @deprecated use {@code defaulhost} instead, this will be removed before 1.0 */
+    @Deprecated
     public final String domainHost;
 
     final String host;

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Batch.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Batch.java
@@ -124,6 +124,7 @@ public final class Batch implements SharedCommonOperations<Batch> {
         return this;
     }
 
+    /** @deprecated use {@link #add(Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     @Override
     public Batch add(Address address, Parameters parameters) {
@@ -148,6 +149,7 @@ public final class Batch implements SharedCommonOperations<Batch> {
         return this;
     }
 
+    /** @deprecated use {@link #invoke(String, Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     @Override
     public Batch invoke(String operationName, Address address, Parameters parameters) {

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Operations.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Operations.java
@@ -138,6 +138,7 @@ public final class Operations implements SharedCommonOperations<ModelNodeResult>
         return client.execute(builder.add(address));
     }
 
+    /** @deprecated use {@link #add(Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     @Override
     public ModelNodeResult add(Address address, Parameters parameters) throws IOException {
@@ -159,6 +160,7 @@ public final class Operations implements SharedCommonOperations<ModelNodeResult>
         return client.execute(builder.invoke(operationName, address));
     }
 
+    /** @deprecated use {@link #invoke(String, Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     @Override
     public ModelNodeResult invoke(String operationName, Address address, Parameters parameters) throws IOException {

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/OperationsModelNodeBuilder.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/OperationsModelNodeBuilder.java
@@ -172,6 +172,7 @@ final class OperationsModelNodeBuilder implements SharedCommonOperations<ModelNo
         return add(address, Values.NONE);
     }
 
+    /** @deprecated use {@link #add(Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     @Override
     public ModelNode add(Address address, Parameters parameters) {
@@ -200,6 +201,7 @@ final class OperationsModelNodeBuilder implements SharedCommonOperations<ModelNo
         return invoke(operationName, address, Values.NONE);
     }
 
+    /** @deprecated use {@link #invoke(String, Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     @Override
     public ModelNode invoke(String operationName, Address address, Parameters parameters) {

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Parameters.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Parameters.java
@@ -29,6 +29,8 @@ import java.util.List;
  * if (bbb != null) <b>params =</b> params.add("bbb", bbb);
  * if (ccc != null) <b>params =</b> params.add("ccc", ccc);
  * </pre>
+ *
+ * @deprecated use {@link Values} instead, this will be removed before 1.0
  */
 @Deprecated
 public final class Parameters {

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/SharedCommonOperations.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/SharedCommonOperations.java
@@ -41,6 +41,7 @@ interface SharedCommonOperations<T> {
 
     T add(Address address) throws IOException;
 
+    /** @deprecated use {@link #add(Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     T add(Address address, Parameters parameters) throws IOException;
 
@@ -50,6 +51,7 @@ interface SharedCommonOperations<T> {
 
     T invoke(String operationName, Address address) throws IOException;
 
+    /** @deprecated use {@link #invoke(String, Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     T invoke(String operationName, Address address, Parameters parameters) throws IOException;
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/SingleOperation.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/SingleOperation.java
@@ -130,6 +130,7 @@ public final class SingleOperation implements SharedCommonOperations<SingleOpera
         return new DeferredOperation(builder.add(address));
     }
 
+    /** @deprecated use {@link #add(Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     @Override
     public DeferredOperation add(Address address, Parameters parameters) {
@@ -151,6 +152,7 @@ public final class SingleOperation implements SharedCommonOperations<SingleOpera
         return new DeferredOperation(builder.invoke(operationName, address));
     }
 
+    /** @deprecated use {@link #invoke(String, Address, Values)} instead, this will be removed before 1.0 */
     @Deprecated
     @Override
     public DeferredOperation invoke(String operationName, Address address, Parameters parameters) {

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Values.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Values.java
@@ -125,7 +125,7 @@ public final class Values {
         return new Values(properties);
     }
 
-    // only for conversion from Parameters, remove when Parameters are removed
+    /** @deprecated only for conversion from {@code Parameters}, remove when {@code Parameters} are removed */
     @Deprecated
     static Values from(List<Property> propertyList) {
         return new Values(propertyList);


### PR DESCRIPTION
All deprecated elements now have _both_ the `@Deprecated` annotation
and the `@deprecated` javadoc tag with instructions.

Resolves #8.