### PR TITLE
fix inconsistent ManagementProtocol enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.3 (not yet released)
+
+- `ManagementProtocol.REMOTING` and `HTTP_REMOTE` renamed to `REMOTE`
+  and `HTTP_REMOTING`; the old names are still available, but deprecated
+  and scheduled for removal
+
 ## 0.9.2
 
 - added command `AddSocketBinding`

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ only reasonable action is aborting everything and reporting a major fail.
 #### WildFly
 
 By default, `OnlineOptions.standalone().localDefault()` configures a management
-client that connects to `localhost:9999` using the `remoting` protocol, which
+client that connects to `localhost:9999` using the `remote` protocol, which
 makes sense for JBoss AS 7.
 
 If you want to connect to WildFly (any version), you can use the `protocol`
@@ -265,16 +265,16 @@ method:
     ManagementClient.online(OnlineOptions
             .standalone()
             .localDefault()
-            .protocol(ManagementProtocol.HTTP_REMOTE)
+            .protocol(ManagementProtocol.HTTP_REMOTING)
             .build()
     );
 
-This changes the protocol to `http-remote` and also changes the default port
+This changes the protocol to `http-remoting` and also changes the default port
 to `9990`. If you define the port directly (using `hostAndPort`), you still
 have to define the correct protocol.
 
-Also, you can use `.protocol(ManagementProtocol.REMOTING)` to switch
-the protocol back to `remoting`, which is useful when using WildFly client
+Also, you can use `.protocol(ManagementProtocol.REMOTE)` to switch
+the protocol back to `remote`, which is useful when using WildFly client
 libraries against an AS7-based server. (It can't work the other way around,
 so if you have AS7 client libraries and specify `http-remoting`, you'll get
 an exception.)

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/ManagementProtocol.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/ManagementProtocol.java
@@ -2,8 +2,15 @@ package org.wildfly.extras.creaper.core.online;
 
 public enum ManagementProtocol {
     /** Used in JBoss AS 7. Default port 9999. */
-    REMOTING("remote"),
+    REMOTE("remote"),
     /** Used in WildFly. Default port 9990. */
+    HTTP_REMOTING("http-remoting"),
+
+    /** @deprecated use {@link #REMOTE} instead, this will be removed before 1.0 */
+    @Deprecated
+    REMOTING("remote"),
+    /** @deprecated use {@link #HTTP_REMOTING} instead, this will be removed before 1.0 */
+    @Deprecated
     HTTP_REMOTE("http-remoting"),
     ;
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
@@ -53,14 +53,14 @@ public final class OnlineOptions {
 
     private OnlineOptions(Data data) {
         if (data.protocol == null && System.getProperty(CREAPER_WILDFLY) != null) {
-            data.protocol = ManagementProtocol.HTTP_REMOTE;
+            data.protocol = ManagementProtocol.HTTP_REMOTING;
             // if the protocol wasn't set manually and the system property isn't set,
-            // it _doesn't_ mean that it's "remoting"! see also OptionalOnlineOptions.protocol below
+            // it _doesn't_ mean that it's "remote"! see also OptionalOnlineOptions.protocol below
         }
 
         if (data.localDefault) {
             data.host = "localhost";
-            data.port = data.protocol == ManagementProtocol.HTTP_REMOTE ? 9990 : 9999;
+            data.port = data.protocol == ManagementProtocol.HTTP_REMOTING ? 9990 : 9999;
         }
 
         this.isStandalone = data.isStandalone;
@@ -265,12 +265,12 @@ public final class OnlineOptions {
          * <p>This also affects the <i>server port</i>, if {@link ConnectionOnlineOptions#localDefault() localDefault}
          * is used.</p>
          *
-         * <p>AS7 uses a native remoting protocol, while WildFly uses the remoting protocol wrapped in HTTP
-         * (using the HTTP upgrade mechanism). When the client libraries on classpath match the server version,
-         * they should choose the correct protocol automatically, so in this situation, this method is not required.
-         * However, when using a single set of client libraries for all server versions (which is possible, because
-         * the client libraries should be backward compatible), this method must be used to specify the type
-         * of the server.</p>
+         * <p>AS7 uses a native remoting protocol, called {@code remote}. WildFly uses the remoting protocol wrapped
+         * in HTTP (using the HTTP upgrade mechanism), called {@code http-remoting}. When the client libraries
+         * on classpath match the server version, they should choose the correct protocol automatically, so in this
+         * situation, this method is not required. However, when using a single set of client libraries for all server
+         * versions (which is possible, because the client libraries should be backward compatible), this method must
+         * be used to specify the type of the server.</p>
          *
          * <p>The server port is only affected by this method when
          * {@link ConnectionOnlineOptions#localDefault() localDefault} is used. When server port is specified directly
@@ -279,8 +279,8 @@ public final class OnlineOptions {
          *
          * <p>If the {@code creaper.wildfly} system property is set (because of
          * {@link ConnectionOnlineOptions#localDefault() localDefault}), it is also used as a signal that the protocol
-         * should be {@code http-remote}, but this method has a priority. When the system property is not set,
-         * it <i>doesn't</i> mean that the protocol should be {@code remoting}; we simply don't know.</p>
+         * should be {@code http-remoting}, but this method has a priority. When the system property is not set,
+         * it <i>doesn't</i> mean that the protocol should be {@code remote}; we simply don't know.</p>
          */
         public OptionalOnlineOptions protocol(ManagementProtocol protocol) {
             if (protocol == null) {
@@ -299,8 +299,8 @@ public final class OnlineOptions {
             }
 
             return protocol(serverType == ServerType.WILDFLY
-                    ? ManagementProtocol.HTTP_REMOTE
-                    : ManagementProtocol.REMOTING);
+                    ? ManagementProtocol.HTTP_REMOTING
+                    : ManagementProtocol.REMOTE);
         }
 
         /** Build the final {@code OnlineOptions}. */
@@ -369,7 +369,7 @@ public final class OnlineOptions {
             return (ModelControllerClient) createMethod.invoke(null, // static method
                     protocolName, host, port, callbackHandler, null, connectionTimeout, saslOptions);
         } catch (NoSuchMethodException e) {
-            if (protocol == ManagementProtocol.HTTP_REMOTE) {
+            if (protocol == ManagementProtocol.HTTP_REMOTING) {
                 // user asks for WildFly, but the client library is from AS7, this can't work
                 throw new IllegalStateException("The server should be WildFly (either ManagementProtocol.HTTP_REMOTING was used or the '"
                         + CREAPER_WILDFLY + "' system property was set), but client libraries are AS7-only");


### PR DESCRIPTION
The enum values in `ManagementProtocol` used to be called `REMOTING` and `HTTP_REMOTE`, yet the real protocol names are `remote` and `http-remoting`. This is confusing. This commit deprecates the bad names and provides correct ones that are consistent with the protocol names (`REMOTE` and `HTTP_REMOTING`).

Fixes #29