### PR TITLE
fix Administration.reload when the server is in "restart-required"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `ManagementProtocol.REMOTING` and `HTTP_REMOTE` renamed to `REMOTE`
   and `HTTP_REMOTING`; the old names are still available, but deprecated
   and scheduled for removal
+- fixed `Administration.reload` when the server is in `restart-required`
 
 ## 0.9.2
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/DomainAdministrationOperations.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/DomainAdministrationOperations.java
@@ -165,13 +165,12 @@ final class DomainAdministrationOperations implements AdministrationOperations {
         if (servers == null || servers.isEmpty()) {
             ModelNodeResult result = ops.readAttribute(Address.host(host), Constants.HOST_STATE);
             result.assertDefinedValue();
-            return Constants.CONTROLLER_PROCESS_STATE_RUNNING.equals(result.stringValue());
+            return ServerState.isRunning(result.stringValue());
         } else {
             for (String server : servers) {
                 Address serverAddress = hostAddress.and(Constants.SERVER, server);
                 ModelNodeResult result = ops.readAttribute(serverAddress, Constants.SERVER_STATE);
-                if (!result.hasDefinedValue()
-                        || !Constants.CONTROLLER_PROCESS_STATE_RUNNING.equals(result.stringValue())) {
+                if (!result.hasDefinedValue() || !ServerState.isRunning(result.stringValue())) {
                     return false;
                 }
             }

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/ServerState.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/ServerState.java
@@ -1,0 +1,13 @@
+package org.wildfly.extras.creaper.core.online.operations.admin;
+
+import org.wildfly.extras.creaper.core.online.Constants;
+
+final class ServerState {
+    private ServerState() {} // avoid instantiation
+
+    static boolean isRunning(String serverState) {
+        return Constants.CONTROLLER_PROCESS_STATE_RUNNING.equals(serverState)
+                || Constants.CONTROLLER_PROCESS_STATE_RELOAD_REQUIRED.equals(serverState)
+                || Constants.CONTROLLER_PROCESS_STATE_RESTART_REQUIRED.equals(serverState);
+    }
+}

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/StandaloneAdministrationOperations.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/StandaloneAdministrationOperations.java
@@ -112,6 +112,6 @@ final class StandaloneAdministrationOperations implements AdministrationOperatio
     private boolean isServerRunning() throws IOException {
         ModelNodeResult result = ops.readAttribute(Address.root(), Constants.SERVER_STATE);
         result.assertDefinedValue();
-        return Constants.CONTROLLER_PROCESS_STATE_RUNNING.equals(result.stringValue());
+        return ServerState.isRunning(result.stringValue());
     }
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/core/online/operations/admin/ReloadWhenRestartRequiredTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/core/online/operations/admin/ReloadWhenRestartRequiredTest.java
@@ -1,0 +1,90 @@
+package org.wildfly.extras.creaper.core.online.operations.admin;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineOptions;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.test.ManualTests;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This test <b>needs</b> a manually-controlled Arquillian container and <b>can't</b> use
+ * {@code Administration.restart}, because it's not possible to restart the application server via management
+ * interface ({@code :shutdown(restart=true)}) if it was started by Arquillian. This is because restarting the entire
+ * JVM process relies on the start script ({@code standalone.sh}), which Arquillian doesn't use.
+ */
+@Category(ManualTests.class)
+@RunWith(Arquillian.class)
+public class ReloadWhenRestartRequiredTest {
+    private OnlineManagementClient client = ManagementClient.onlineLazy(
+            OnlineOptions.standalone().localDefault().build());
+    private Operations ops = new Operations(client);
+    private Administration admin = new Administration(client);
+
+    @ArquillianResource
+    private ContainerController controller;
+
+    @Test
+    @InSequence(1)
+    public void startServer() {
+        controller.start(ManualTests.ARQUILLIAN_CONTAINER);
+    }
+
+    @Test
+    @InSequence(2)
+    public void bringTheServerToRestartRequiredAndThenReload() throws Exception {
+        ops.writeAttribute(Address.subsystem("transactions"), "jts", true);
+        assertTrue(admin.isRestartRequired());
+        assertFalse(admin.isReloadRequired());
+
+        ops.writeAttribute(Address.subsystem("transactions"), "jts", false);
+        assertTrue(admin.isRestartRequired());
+        assertFalse(admin.isReloadRequired());
+
+        admin.reload();
+
+        assertTrue(admin.isRestartRequired());
+        assertFalse(admin.isReloadRequired());
+
+    }
+
+    @Test
+    @InSequence(3)
+    public void restartServer() throws TimeoutException, InterruptedException {
+        controller.stop(ManualTests.ARQUILLIAN_CONTAINER);
+        controller.start(ManualTests.ARQUILLIAN_CONTAINER);
+        client.reconnect(10);
+    }
+
+    @Test
+    @InSequence(4)
+    public void assertRestartIsNotRequired() throws IOException {
+        assertFalse(admin.isRestartRequired());
+        assertFalse(admin.isReloadRequired());
+    }
+
+    @Test
+    @InSequence(5)
+    public void stopServer() {
+        controller.stop(ManualTests.ARQUILLIAN_CONTAINER);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        client.close();
+    }
+}


### PR DESCRIPTION
Calling `Administration.reload` when the server is in state `restart-required` used to timeout instead of returning normally. This was caused by the method waiting for the server to get into the state `running`. However, reloading a server that is in `restart-required` leads directly to `restart-required`. This commit fixes the problem by accounting for that possibility.

Fixes #31