### PR TITLE
avoid exceptions when Operations.removeIfExists is called from command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   when `replaceExisting()` is used
 - the test suite now uses latest WildFly 10 pre-release (was blocked
   by wrong patching test)
+- fixed a failure when `Operations.batch` was passed an empty `Batch`
+- added `OnlineManagementClient.expectedFailures` to avoid exceptions
+  when operations are executed from commands and failures are expected
+  (e.g. `Operations.exists` or `Operations.removeIfExists`)
 
 ## 0.9.2
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineCommand.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineCommand.java
@@ -7,7 +7,7 @@ import org.wildfly.extras.creaper.core.Command;
  * A command is typically comprised of multiple management operations and is <b>not</b> transactional. It is expected
  * that there will be <b>no</b> other process manipulating the same configuration file.</p>
  *
- * <p>Error handling for commands is provided automatically by the {@code ManagementClient}. That is, if you are
+ * <p>Error handling for commands is provided automatically by the {@code ManagementClient}. That is, when you are
  * implementing the {@code apply} method, you <i>should</i> let all the exceptions bubble up. Only catch exceptions
  * if you can recover from them. This is signified by the {@code throws} clause of the {@code apply} method anyway.</p>
  */

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/FailuresAllowedBlock.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/FailuresAllowedBlock.java
@@ -1,0 +1,29 @@
+package org.wildfly.extras.creaper.core.online;
+
+import java.io.Closeable;
+
+/**
+ * <p>The only function this interface exposes is the ability to end a block of code started by
+ * {@link OnlineManagementClient#allowFailures()}:</p>
+ *
+ * <pre>
+ * FailuresAllowedBlock allowFailures = client.allowFailures();
+ * try {
+ *     ModelNodeResult result = client.execute(...);
+ *     ...
+ * } finally {
+ *     allowFailures.close();
+ * }
+ * </pre>
+ *
+ * <p>If using Java 7 and above, a try-with-resources block will make the code shorter:</p>
+ *
+ * <pre>
+ * try (FailuresAllowedBlock allowFailures = client.allowFailures()) {
+ *     ModelNodeResult result = client.execute(...);
+ *     ...
+ * }
+ * </pre>
+ */
+public interface FailuresAllowedBlock extends Closeable {
+}

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/LazyOnlineManagementClient.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/LazyOnlineManagementClient.java
@@ -93,6 +93,12 @@ final class LazyOnlineManagementClient implements OnlineManagementClient {
     }
 
     @Override
+    public FailuresAllowedBlock allowFailures() throws IOException {
+        ensureInitialized();
+        return delegate.allowFailures();
+    }
+
+    @Override
     public void close() throws IOException {
         if (delegate != null) {
             delegate.close();

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/NoopCloseFailuresAllowedBlock.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/NoopCloseFailuresAllowedBlock.java
@@ -1,0 +1,14 @@
+package org.wildfly.extras.creaper.core.online;
+
+import java.io.IOException;
+
+/** An implementation of {@link FailuresAllowedBlock} whose {@code close} method is a no-op. */
+final class NoopCloseFailuresAllowedBlock implements FailuresAllowedBlock {
+    static final NoopCloseFailuresAllowedBlock INSTANCE = new NoopCloseFailuresAllowedBlock();
+
+    private NoopCloseFailuresAllowedBlock() {}
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineCommand.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineCommand.java
@@ -7,9 +7,12 @@ import org.wildfly.extras.creaper.core.Command;
  * A command is typically comprised of multiple management operations and is <b>not</b> transactional. It is expected
  * that there will be <b>no</b> other management clients connected to the same application server.</p>
  *
- * <p>Error handling for commands is provided automatically by the {@code ManagementClient}. That is, if you are
- * implementing the {@code apply} method, you <i>should</i> let all the exceptions bubble up. Only catch exceptions
- * if you can recover from them. This is signified by the {@code throws} clause of the {@code apply} method anyway.</p>
+ * <p>Error handling for commands is provided automatically by the {@code ManagementClient}. Most importantly, all
+ * management operation results are inspected and if the operation failed, an exception is thrown for you. This should
+ * be the common case; if you expect operation failures in a certain block of code, delimit that block of code using
+ * {@link OnlineManagementClient#allowFailures()}. When you are implementing the {@code apply} method, you
+ * <i>should</i> let all the exceptions bubble up. Only catch exceptions if you can recover from them. This is signified
+ * by the {@code throws} clause of the {@code apply} method anyway.</p>
  */
 public interface OnlineCommand extends Command {
     void apply(OnlineCommandContext ctx) throws Exception;

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineManagementClient.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineManagementClient.java
@@ -86,6 +86,21 @@ public interface OnlineManagementClient extends Closeable {
     void reconnect(int timeoutInSeconds) throws TimeoutException, InterruptedException;
 
     /**
+     * <p><b>This method can typically be ignored</b>; it's only important when management operations on this client
+     * can be performed from inside an {@link OnlineCommand} and failures of these operations are expected.
+     * Specifically, inside a command, operation failures are automatically converted to exceptions (see
+     * {@link OnlineCommand}). However, in some situations, this is wrong, because you may expect the failure
+     * and act on it. In such situations, you want to use this method.</p>
+     *
+     * <p>This method starts a block of code in which management operations performed by this client are allowed
+     * to fail. Inside that block, operation failures are <i>not</i> converted to exceptions.
+     * The {@link FailuresAllowedBlock} must be {@code close}d to end this behavior. Nesting is supported
+     * (i.e., you can call {@code allowFailures} inside an failures-allowed block, but you must close
+     * the inner block before closing the outer block).</p>
+     */
+    FailuresAllowedBlock allowFailures() throws IOException;
+
+    /**
      * Closes the client and releases all the resources held. In contrast to the offline management client, which
      * doesn't manage any resources, it is <b>needed</b> here.
      * @throws IOException if an I/O error occurs

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineManagementClientImpl.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineManagementClientImpl.java
@@ -240,6 +240,13 @@ final class OnlineManagementClientImpl implements OnlineManagementClient {
     }
 
     @Override
+    public FailuresAllowedBlock allowFailures() throws IOException {
+        // no need to do anything here
+        // this must mainly be implemented in AutomaticErrorHandlingForCommands
+        return NoopCloseFailuresAllowedBlock.INSTANCE;
+    }
+
+    @Override
     public void close() throws IOException {
         client.close();
         cliContext.disconnectController();

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/core/online/operations/OperationsTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/core/online/operations/OperationsTest.java
@@ -2,11 +2,14 @@ package org.wildfly.extras.creaper.core.online.operations;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.dmr.ModelNode;
+import org.wildfly.extras.creaper.core.CommandFailedException;
 import org.wildfly.extras.creaper.core.ManagementClient;
 import org.wildfly.extras.creaper.core.ManagementVersion;
 import org.wildfly.extras.creaper.core.ManagementVersionPart;
 import org.wildfly.extras.creaper.core.online.Constants;
 import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineCommand;
+import org.wildfly.extras.creaper.core.online.OnlineCommandContext;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.OnlineOptions;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
@@ -390,6 +393,21 @@ public class OperationsTest {
 
     @Test
     public void exists() throws IOException, OperationException {
+        doExists(ops);
+    }
+
+    @Test
+    public void exists_inCommand() throws CommandFailedException {
+        client.apply(new OnlineCommand() {
+            @Override
+            public void apply(OnlineCommandContext ctx) throws Exception {
+                Operations ops = new Operations(ctx.client);
+                doExists(ops);
+            }
+        });
+    }
+
+    private void doExists(Operations ops) throws IOException, OperationException {
         assertTrue(ops.exists(Address.root()));
         assertTrue(ops.exists(Address.subsystem("infinispan")));
         assertTrue(ops.exists(Address.subsystem("infinispan").and("cache-container", "web")));
@@ -399,6 +417,21 @@ public class OperationsTest {
 
     @Test
     public void removeIfExists() throws IOException, OperationException {
+        doRemoveIfExists(ops);
+    }
+
+    @Test
+    public void removeIfExists_inCommand() throws CommandFailedException {
+        client.apply(new OnlineCommand() {
+            @Override
+            public void apply(OnlineCommandContext ctx) throws Exception {
+                Operations ops = new Operations(ctx.client);
+                doRemoveIfExists(ops);
+            }
+        });
+    }
+
+    private void doRemoveIfExists(Operations ops) throws IOException, OperationException {
         Address address = Address.subsystem("infinispan").and("cache-container", "xyz");
 
         boolean result = ops.removeIfExists(address);


### PR DESCRIPTION
When calling `Operations.removeIfExists` outside of an `OnlineCommand`, it returns `false` correctly when the desired management resource doesn't exist. However, when it's called from an `OnlineCommand`, it throws an exception. The reason is that inside a command, the management client is wrapped in a proxy that detects failed management operations and throws exceptions automatically, so that commands don't have to do that.

This is an important convenience that needs to be retained. However, sometimes it's simply expected that an operation will fail (`Operations.removeIfExists` is one case, `Operations.exists` is another and one could argue that this can happen for user-constructed operations as well). So there needs to be a way to communicate such intent from inside the command. If we were on Java 8, a lambda would be natural, but on Java 6, this is simply too unwieldy. Instead, a new method `allowFailures` is added to `OnlineManagementClient` that returns a `Closeable`. Calling that method and closing its result delimit the block of code in which failures shouldn't be converted to exceptions because they are expected. This is still somewhat wordy in Java 6, but in Java 7 and above, try-with-resources can be used to bring the syntactic overhead down.

Fixes #40