### PR TITLE
Allow defining security realm without truststore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 .settings
 .recommenders
 .checkstyle
+*.log

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/undertow/AddHttpsSecurityRealm.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/undertow/AddHttpsSecurityRealm.java
@@ -141,7 +141,7 @@ public final class AddHttpsSecurityRealm implements OnlineCommand {
         }
 
         /**
-         * Defines the password to open the keystore.
+         * Defines the password to open the keystore. This is mandatory parameter which needs to be set.
          */
         public Builder keystorePassword(String keystorePassword) {
             this.keystorePassword = keystorePassword;
@@ -191,7 +191,7 @@ public final class AddHttpsSecurityRealm implements OnlineCommand {
         }
 
         /**
-         * Defines the password to open the truststore.
+         * Defines the password to open the truststore. It is mandatory parameter when also defining truststore
          */
         public Builder truststorePassword(String truststorePassword) {
             this.truststorePassword = truststorePassword;
@@ -200,6 +200,7 @@ public final class AddHttpsSecurityRealm implements OnlineCommand {
 
         /**
          * Defines the path of the trustore, will be ignored if the truststore provider is anything other than JKS.
+         * If not defined, truststore is not defined for the server.
          */
         public Builder truststorePath(String truststorePath) {
             this.truststorePath = truststorePath;
@@ -225,6 +226,12 @@ public final class AddHttpsSecurityRealm implements OnlineCommand {
         }
 
         public AddHttpsSecurityRealm build() {
+            if (keystorePassword == null) {
+                throw new IllegalArgumentException("keystorePassword is manadatory");
+            }
+            if (truststorePath != null && truststorePassword == null) {
+                throw new IllegalArgumentException("truststorePassword is manadatory when defining also truststore");
+            }
             return new AddHttpsSecurityRealm(this);
         }
     }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/undertow/AddHttpsSecurityRealm.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/undertow/AddHttpsSecurityRealm.java
@@ -70,12 +70,14 @@ public final class AddHttpsSecurityRealm implements OnlineCommand {
                         .andOptional("keystore-relative-to", keystoreRelativeTo)
                         .andOptional("protocol", protocol)
         );
-        batch.add(securityRealmAddress.and("authentication", "truststore"), Values.empty()
-                        .and("keystore-password", truststorePassword)
-                        .andOptional("keystore-path", truststorePath)
-                        .andOptional("keystore-provider", truststoreProvider)
-                        .andOptional("keystore-relative-to", truststoreRelativeTo)
-        );
+        if (truststorePath != null) {
+            batch.add(securityRealmAddress.and("authentication", "truststore"), Values.empty()
+                    .and("keystore-password", truststorePassword)
+                    .andOptional("keystore-path", truststorePath)
+                    .andOptional("keystore-provider", truststoreProvider)
+                    .andOptional("keystore-relative-to", truststoreRelativeTo)
+            );
+        }
 
         ops.batch(batch);
     }

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/undertow/AddUndertowListenerOnlineTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/undertow/AddUndertowListenerOnlineTest.java
@@ -108,7 +108,29 @@ public class AddUndertowListenerOnlineTest {
         assertFalse(ops.exists(DEFAULT_SERVER_ADDRESS.and("https-listener", TEST_LISTENER_NAME)));
 
         client.apply(new RemoveHttpsSecurityRealm(realmName));
+        admin.reloadIfRequired();
     }
+
+    @Test
+    public void addSecurityRealm_withoutTruststore_commandSucceeds() throws Exception {
+        String alias = "creaper";
+        File keystoreFile = tmp.newFile();
+        KeyStore keyStore = KeyPairAndCertificate.generateSelfSigned("Creaper").toKeyStore(alias, TEST_PASSWORD);
+        keyStore.store(new FileOutputStream(keystoreFile), TEST_PASSWORD.toCharArray());
+
+        String realmName = "CreaperRealm";
+
+        client.apply(new AddHttpsSecurityRealm.Builder(realmName)
+                .keystorePath(keystoreFile.getAbsolutePath())
+                .keystorePassword(TEST_PASSWORD)
+                .alias(alias)
+                .build());
+        assertTrue(ops.exists(Address.coreService("management").and("security-realm", realmName)));
+
+        client.apply(new RemoveHttpsSecurityRealm(realmName));
+        admin.reloadIfRequired();
+    }
+
 
     @Test
     public void addAjpConnector_commandSucceeds() throws Exception {


### PR DESCRIPTION
based on whether truststorePath is provided decides whether also add truststore or not. Test included.

fixes #49