### PR TITLE
fix the treatment of default host in managed domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 0.9.6 (not yet released)
 
 - offline commands for security now check the configuration file version
+- `OfflineOptions.defaultHost` and `.forHost` make no sense because
+  an offline client always works with a single file, so they are now
+  deprecated and scheduled for removal
+- if `OnlineOptions.forHost` wasn't called and `OnlineOptions.defaultHost`
+  is therefore `null`, operations against addresses `/core-service=...`
+  are now performed as-is instead of throwing an exception
 
 ## 0.9.5
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineOptions.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineOptions.java
@@ -16,6 +16,8 @@ public final class OfflineOptions {
 
     public final boolean isDomain;
     public final String defaultProfile;
+    /** @deprecated always {@code null}, doesn't make sense for offline client; will be removed before 1.0 */
+    @Deprecated
     public final String defaultHost;
     /** @deprecated use {@code defaulProfile} instead, this will be removed before 1.0 */
     @Deprecated
@@ -32,9 +34,9 @@ public final class OfflineOptions {
 
         this.isDomain = data.isDomain;
         this.defaultProfile = data.defaultProfile;
-        this.defaultHost = data.defaultHost;
+        this.defaultHost = null;
         this.domainProfile = data.defaultProfile;
-        this.domainHost = data.defaultHost;
+        this.domainHost = null;
 
         this.configurationDirectory = data.configurationDirectory;
         this.configurationFile = data.configurationFile;
@@ -63,7 +65,6 @@ public final class OfflineOptions {
 
         private boolean isDomain;
         private String defaultProfile;
-        private String defaultHost;
 
         private File configurationDirectory;
         private File configurationFile;
@@ -102,15 +103,9 @@ public final class OfflineOptions {
             return this;
         }
 
-        /** Apply host configuration changes to the {@code host}. Optional, can only be called once.  */
+        /** @deprecated does nothing, doesn't make sense for offline client; will be removed before 1.0 */
+        @Deprecated
         public DomainOfflineOptions forHost(String host) {
-            assert data.isDomain;
-
-            if (data.defaultHost != null) {
-                throw new IllegalStateException("Host was already set (" + data.defaultHost + ")");
-            }
-
-            data.defaultHost = host;
             return this;
         }
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/AdjustOperationForDomain.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/AdjustOperationForDomain.java
@@ -14,12 +14,11 @@ import java.util.List;
  *
  * <p>Operations that are meant for standalone and are convertible for domain usage are:</p>
  * <ul>
- * <li>operations whose addresses start with {@code /subsystem=...} &ndash; {@code /profile=...} is prepended</li>
- * <li>operations whose addresses start with {@code /core-service=...} &ndash; {@code /host=...} is prepended</li>
+ * <li>operations whose addresses start with {@code /subsystem=...} &ndash; {@code /profile=...} is prepended;
+ *     if there is no default profile, an {@link IllegalArgumentException} is thrown</li>
+ * <li>operations whose addresses start with {@code /core-service=...} &ndash; {@code /host=...} is prepended;
+ *     if there is no default host, the operation is executed as-is (without any transformation)</li>
  * </ul>
- *
- * <p>If an operation is to be adjusted, but default profile/host is not known, an {@link IllegalArgumentException}
- * is thrown.</p>
  */
 final class AdjustOperationForDomain {
     private final OnlineOptions options;
@@ -69,8 +68,7 @@ final class AdjustOperationForDomain {
                 prependToAddress = new Property(Constants.PROFILE, new ModelNode(options.defaultProfile));
                 break;
             }
-            if (Constants.CORE_SERVICE.equals(property.getName())) {
-                checkHost(operation.asString());
+            if (Constants.CORE_SERVICE.equals(property.getName()) && options.defaultHost != null) {
                 prependToAddress = new Property(Constants.HOST, new ModelNode(options.defaultHost));
                 break;
             }
@@ -109,8 +107,7 @@ final class AdjustOperationForDomain {
             checkProfile(cliOperation);
             return "/profile=" + options.defaultProfile + cliOperation;
         }
-        if (cliOperation.startsWith("/core-service")) {
-            checkHost(cliOperation);
+        if (cliOperation.startsWith("/core-service") && options.defaultHost != null) {
             return "/host=" + options.defaultHost + cliOperation;
         }
 
@@ -120,12 +117,6 @@ final class AdjustOperationForDomain {
     private void checkProfile(String operation) {
         if (options.defaultProfile == null) {
             throw new IllegalArgumentException("No default profile, can't perform operation in domain: " + operation);
-        }
-    }
-
-    private void checkHost(String operation) {
-        if (options.defaultHost == null) {
-            throw new IllegalArgumentException("No default host, can't perform operation in domain: " + operation);
         }
     }
 }

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
@@ -31,10 +31,10 @@ public final class OnlineOptions {
     public final boolean isDomain;
     public String defaultProfile;
     public String defaultHost;
-    /** @deprecated use {@code defaulProfile} instead, this will be removed before 1.0 */
+    /** @deprecated use {@code defaultProfile} instead, this will be removed before 1.0 */
     @Deprecated
     public final String domainProfile;
-    /** @deprecated use {@code defaulhost} instead, this will be removed before 1.0 */
+    /** @deprecated use {@code defaultHost} instead, this will be removed before 1.0 */
     @Deprecated
     public final String domainHost;
 
@@ -127,24 +127,36 @@ public final class OnlineOptions {
             this.data = data;
         }
 
-        /** Apply profile configuration changes to the {@code profile}. Optional, can only be called once.  */
+        /**
+         * <p>Apply profile configuration changes to the {@code profile}. Optional, can only be called once.</p>
+         *
+         * <p>If set, operations on addresses {@code /subsystem=...} will be automatically performed against
+         * an address {@code /profile=.../subsystem=...}. If not set, an exception will be thrown when
+         * trying to execute an operation on address {@code /subsystem=...}.</p>
+         */
         public DomainOnlineOptions forProfile(String profile) {
             assert data.isDomain;
 
             if (data.defaultProfile != null) {
-                throw new IllegalStateException("Profile was already set (" + data.defaultProfile + ")");
+                throw new IllegalStateException("Default profile was already set (" + data.defaultProfile + ")");
             }
 
             data.defaultProfile = profile;
             return this;
         }
 
-        /** Apply host configuration changes to the {@code host}. Optional, can only be called once.  */
+        /**
+         * <p>Apply host configuration changes to the {@code host}. Optional, can only be called once.</p>
+         *
+         * <p>If set, operations on addresses {@code /core-service=...} will be automatically performed against
+         * an address {@code /host=.../core-service=...}. If not set, the operation will be performed against
+         * the original address.</p>
+         */
         public DomainOnlineOptions forHost(String host) {
             assert data.isDomain;
 
             if (data.defaultHost != null) {
-                throw new IllegalStateException("Host was already set (" + data.defaultHost + ")");
+                throw new IllegalStateException("Default host was already set (" + data.defaultHost + ")");
             }
 
             data.defaultHost = host;

--- a/core/src/test/java/org/wildfly/extras/creaper/core/online/AdjustOperationForDomainTest.java
+++ b/core/src/test/java/org/wildfly/extras/creaper/core/online/AdjustOperationForDomainTest.java
@@ -190,11 +190,11 @@ public class AdjustOperationForDomainTest {
         adjust.adjust("/subsystem=web:read-resource");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void unknownHost() {
         OnlineOptions options = OnlineOptions.domain().build().localDefault().build();
         AdjustOperationForDomain adjust = new AdjustOperationForDomain(options);
 
-        adjust.adjust("/core-service=management:read-resource");
+        assertEquals("/core-service=management:read-resource", adjust.adjust("/core-service=management:read-resource"));
     }
 }


### PR DESCRIPTION
With the offline client, the notion of default host doesn't make any sense, because the client always works with a single file.

With online client, default host is used to transform operations on addresses `/core-service=...` to `/host=.../core-service=...`, and if there is no default host to prepend, an exception is thrown. That, however, is wrong, because there are legitimate uses of operations on `/core-service=...` in managed domain, e.g. RBAC. The solution is simple -- if there's no default host defined, the operation will be executed unchanged.

Fixes #72.