### PR TITLE
update GroovyXmlTransform to understand new first-level XML elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - if `OnlineOptions.forHost` wasn't called and `OnlineOptions.defaultHost`
   is therefore `null`, operations against addresses `/core-service=...`
   are now performed as-is instead of throwing an exception
+- updated `GroovyXmlTransform` to understand new XML elements added in WildFly
 
 ## 0.9.5
 

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/FirstLevelXmlElementOrderTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/FirstLevelXmlElementOrderTest.java
@@ -1,0 +1,73 @@
+package org.wildfly.extras.creaper.commands.foundation.offline.xml;
+
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+import static org.wildfly.extras.creaper.XmlAssert.assertXmlIdentical;
+
+public class FirstLevelXmlElementOrderTest {
+    private static final String DOMAIN_XML = ""
+            + "<?xml version=\"1.0\" ?>\n"
+            + "<domain xmlns=\"urn:jboss:domain:4.1\">\n"
+            + "    <extensions/>\n"
+            + "    <system-properties/>\n"
+            + "    <management/>\n"
+            + "    <profiles/>\n"
+            + "    <interfaces/>\n"
+            + "    <socket-binding-groups/>\n"
+            + "    <server-groups/>\n"
+            + "</domain>";
+
+    private static final String HOST_XML = ""
+            + "<?xml version=\"1.0\" ?>\n"
+            + "<host xmlns=\"urn:jboss:domain:4.1\" name=\"master\">\n"
+            + "    <extensions/>\n"
+            + "    <management/>\n"
+            + "    <domain-controller/>\n"
+            + "    <interfaces/>\n"
+            + "    <jvms/>\n"
+            + "    <servers/>\n"
+            + "    <profile/>\n"
+            + "</host>";
+
+    private static final String SERVER_XML = ""
+            + "<?xml version=\"1.0\"?>\n"
+            + "<server xmlns=\"urn:jboss:domain:4.1\">\n"
+            + "    <extensions/>\n"
+            + "    <management/>\n"
+            + "    <profile/>\n"
+            + "    <interfaces/>\n"
+            + "    <socket-binding-group/>\n"
+            + "</server>";
+
+    private static final String UNKNOWN_XML = "<foobar/>";
+
+    @BeforeClass
+    public static void setUpXmlUnit() {
+        XMLUnit.setIgnoreWhitespace(true);
+    }
+
+    @Test
+    public void domain() throws IOException, SAXException {
+        assertXmlIdentical(DOMAIN_XML, FirstLevelXmlElementOrder.fix(DOMAIN_XML));
+    }
+
+    @Test
+    public void host() throws IOException, SAXException {
+        assertXmlIdentical(HOST_XML, FirstLevelXmlElementOrder.fix(HOST_XML));
+    }
+
+    @Test
+    public void server() throws IOException, SAXException {
+        assertXmlIdentical(SERVER_XML, FirstLevelXmlElementOrder.fix(SERVER_XML));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void unknown() {
+        FirstLevelXmlElementOrder.fix(UNKNOWN_XML);
+    }
+}


### PR DESCRIPTION
WildFly added new elements to the set of possible first-level elements in the XML configuration files. This updates the `Subtree` class to understand them (which requires making a difference between `host.xml` and `domain.xml`, as `host.xml` is suddenly very similar to `standalone.xml`).
    
Also, to maintain correct order of the XML elements, it is no longer sufficient to maintain a single list which blends all the possibilities, so the list was split into three separate lists -- for the `domain` root element, for `host` and for `server`.