### PR TITLE
Fixed location of map-groups-to-roles attribute for AddSecurityRealm offline command

### DIFF
--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/security/realms/AddPropertiesAuthentication.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/security/realms/AddPropertiesAuthentication.java
@@ -79,10 +79,10 @@ public final class AddPropertiesAuthentication extends AbstractAddSecurityRealmS
         @Override
         public AddPropertiesAuthentication build() {
             if (path == null) {
-                throw new IllegalArgumentException("Path of the security domain must be specified as non null value");
+                throw new IllegalArgumentException("Path of the property file must be specified as non null value");
             }
             if (path.isEmpty()) {
-                throw new IllegalArgumentException("Path of the security domain must not be empty value");
+                throw new IllegalArgumentException("Path of the property file must not be empty value");
             }
             return new AddPropertiesAuthentication(this);
         }

--- a/commands/src/main/resources/org/wildfly/extras/creaper/commands/security/realms/AddSecurityRealm.groovy
+++ b/commands/src/main/resources/org/wildfly/extras/creaper/commands/security/realms/AddSecurityRealm.groovy
@@ -1,8 +1,11 @@
 realmAttrs = ['name': atrSecurityRealmName]
-if (atrMapGroupsToRoles != null) realmAttrs['map-groups-to-roles'] = atrMapGroupsToRoles
 
 def realmDefinition = {
-    'security-realm'(realmAttrs)
+    'security-realm'(realmAttrs) {
+        if (atrMapGroupsToRoles != null) {
+            'authorization'(['map-groups-to-roles': atrMapGroupsToRoles])
+        }
+    }
 }
 
 def existingSecurityRealm = management.'security-realms'.'security-realm'.find { it.'@name' == atrSecurityRealmName }

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/security/realms/AddSecurityRealmOfflineTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/security/realms/AddSecurityRealmOfflineTest.java
@@ -38,7 +38,9 @@ public class AddSecurityRealmOfflineTest {
             + "<server xmlns=\"urn:jboss:domain:1.7\">\n"
             + "    <management>\n"
             + "        <security-realms>\n"
-            + "            <security-realm name=\"creaperSecRealm\" map-groups-to-roles=\"true\"/>\n"
+            + "            <security-realm name=\"creaperSecRealm\">\n"
+            + "                <authorization map-groups-to-roles=\"true\"/>"
+            + "            </security-realm>\n"
             + "        </security-realms>\n"
             + "    </management>\n"
             + "</server>";


### PR DESCRIPTION
Attribute 'map-groups-to-roles' must be located in 'authorization' element. Before this fix it was located in 'security-realm' element.

This commit also includes simple fix for message for null or empty path in AddPropertiesAuthentication.