### PR TITLE
Logging api enhancement to set logging category without need of replaceExisting

### DIFF
--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/logging/Logging.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/logging/Logging.java
@@ -44,6 +44,18 @@ public final class Logging {
         public RemoveLogger remove(String category) {
             return new RemoveLogger(category);
         }
+
+        /**
+         * <p>
+         * Setting the logger category when ensuring if exists.<br>
+         * For existing it replaces the log level, for non-existing
+         * it creates new category with provided level.
+         * <p>
+         * This method is equivalent to <code>add(String category).replaceExisting()</code>
+         */
+        public AddLogger.Builder define(String category) {
+            return add(category).replaceExisting();
+        }
     }
 
     public static final class LogHandler {


### PR DESCRIPTION
I would like propose small `Logging` class api enhancement. For setting category level would be fine not need to call `replaceExisting()` for `add` command. When I want just set without thinking if exist or not.

Not adding any test as seems to me not necessary but if you are for to merge and you prefer to have test I will copy some add/replaceExisting one :)