### PR TITLE
Commands for adding/removing infinispan caches

### DIFF
--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AbstractAddCache.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AbstractAddCache.java
@@ -1,0 +1,96 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import org.wildfly.extras.creaper.core.online.OnlineCommand;
+import org.wildfly.extras.creaper.core.online.OnlineCommandContext;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.Values;
+
+abstract class AbstractAddCache implements OnlineCommand {
+
+    private final CacheType cacheType;
+    private final String cacheContainer;
+    private final String name;
+
+    // cache properties common to all cache types
+    private final String jndiName;
+    private final String module;
+    private final String start;
+    private final Boolean statisticsEnabled;
+
+    protected final Address address;
+
+    @Override
+    public final void apply(OnlineCommandContext ctx) throws Exception {
+        Values values = Values.empty()
+                .andOptional("jndi-name", jndiName)
+                .andOptional("module", module)
+                .andOptional("start", start)
+                .andOptional("statistics-enabled", statisticsEnabled);
+        values = addValuesSpecificForCacheType(values);
+
+        Operations ops = new Operations(ctx.client);
+        ops.add(address, values);
+    }
+
+    abstract Values addValuesSpecificForCacheType(Values generalCacheValues);
+
+    AbstractAddCache(Builder builder, CacheType cacheType) {
+        if (builder.cacheContainer == null) {
+            throw new NullPointerException("Cache container is required");
+        }
+        this.cacheContainer = builder.cacheContainer;
+        this.cacheType = cacheType;
+        this.name = builder.name;
+        this.jndiName = builder.jndiName;
+        this.module = builder.module;
+        this.start = builder.start;
+        this.statisticsEnabled = builder.statisticsEnabled;
+        this.address = Address.subsystem("infinispan")
+                .and("cache-container", cacheContainer)
+                .and(cacheType.getType(), name);
+    }
+
+    public abstract static class Builder<THIS extends Builder> {
+
+        protected String name;
+        protected String cacheContainer;
+        protected String jndiName;
+        protected String module;
+        protected String start;
+        protected Boolean statisticsEnabled;
+
+        protected Builder(String name) {
+            if (name == null || name.isEmpty()) {
+                throw new IllegalArgumentException("Name of the cache must be specified");
+            }
+            this.name = name;
+        }
+
+        public final THIS cacheContainer(String cacheContainer) {
+            this.cacheContainer = cacheContainer;
+            return (THIS) this;
+        }
+
+        public final THIS jndiName(String jndiName) {
+            this.jndiName = jndiName;
+            return (THIS) this;
+        }
+
+        public final THIS module(String module) {
+            this.module = module;
+            return (THIS) this;
+        }
+
+        public final THIS start(String start) {
+            this.start = start;
+            return (THIS) this;
+        }
+
+        public final THIS statisticsEnabled(Boolean statisticsEnabled) {
+            this.statisticsEnabled = statisticsEnabled;
+            return (THIS) this;
+        }
+
+    }
+}

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddDistributedCache.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddDistributedCache.java
@@ -1,0 +1,120 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import org.wildfly.extras.creaper.core.online.operations.Values;
+
+public final class AddDistributedCache extends AbstractAddCache {
+
+    private final Boolean asyncMarshalling;
+    private final CacheMode mode;
+    private final Long queueFlushInterval;
+    private final Long remoteTimeout;
+    private final Double capacityFactor;
+    private final ConsistentHashStrategy consistentHashStrategy;
+    private final Long l1lifespan;
+    private final Integer owners;
+    private final Integer segments;
+
+    private AddDistributedCache(Builder builder) {
+        super(builder, CacheType.DISTRIBUTED_CACHE);
+        this.asyncMarshalling = builder.asyncMarshalling;
+        this.mode = builder.mode;
+        this.queueFlushInterval = builder.queueFlushInterval;
+        this.remoteTimeout = builder.remoteTimeout;
+        this.capacityFactor = builder.capacityFactor;
+        this.consistentHashStrategy = builder.consistentHashStrategy;
+        this.l1lifespan = builder.l1lifespan;
+        this.owners = builder.owners;
+        this.segments = builder.segments;
+    }
+
+    @Override
+    Values addValuesSpecificForCacheType(Values generalCacheValues) {
+        return generalCacheValues
+                .andOptional("async-marshalling", asyncMarshalling)
+                .andOptional("mode", mode != null ? mode.getMode() : null)
+                .andOptional("queue-flush-interval", queueFlushInterval)
+                .andOptional("remote-timeout", remoteTimeout)
+                .andOptional("capacity-factor", capacityFactor)
+                .andOptional("consistent-hash-strategy",
+                        consistentHashStrategy != null ? consistentHashStrategy.getType() : null)
+                .andOptional("l1-lifespan", l1lifespan)
+                .andOptional("owners", owners)
+                .andOptional("segments", segments);
+    }
+
+    public static final class Builder extends AbstractAddCache.Builder<Builder> {
+
+        public Builder(String name) {
+            super(name);
+        }
+
+        private Boolean asyncMarshalling;
+        private CacheMode mode;
+        private Long queueFlushInterval;
+        private Long remoteTimeout;
+        private Double capacityFactor;
+        private ConsistentHashStrategy consistentHashStrategy;
+        private Long l1lifespan;
+        private Integer owners;
+        private Integer segments;
+
+        public Builder asyncMarshalling(Boolean asyncMarshalling) {
+            this.asyncMarshalling = asyncMarshalling;
+            return this;
+        }
+
+        public Builder mode(CacheMode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        public Builder queueFlushInterval(Long queueFlushInterval) {
+            this.queueFlushInterval = queueFlushInterval;
+            return this;
+        }
+
+        public Builder remoteTimeout(Long remoteTimeout) {
+            this.remoteTimeout = remoteTimeout;
+            return this;
+        }
+
+        /**
+         * {@code capacity-factor} is only supported on WildFly 9 and above,
+         * this setting will be ignored on previous versions.
+         */
+        public Builder capacityFactor(Double capacityFactor) {
+            this.capacityFactor = capacityFactor;
+            return this;
+        }
+
+        /**
+         * {@code consistent-hash-strategy} is only supported on WildFly 9 and above,
+         * this setting will be ignored on previous versions.
+         */
+        public Builder consistentHashStrategy(ConsistentHashStrategy consistentHashStrategy) {
+            this.consistentHashStrategy = consistentHashStrategy;
+            return this;
+        }
+
+        public Builder l1lifespan(Long l1lifespan) {
+            this.l1lifespan = l1lifespan;
+            return this;
+        }
+
+        public Builder owners(Integer owners) {
+            this.owners = owners;
+            return this;
+        }
+
+        public Builder segments(Integer segments) {
+            this.segments = segments;
+            return this;
+        }
+
+        public AddDistributedCache build() {
+            return new AddDistributedCache(this);
+        }
+
+    }
+
+}

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddInvalidationCache.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddInvalidationCache.java
@@ -1,0 +1,66 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import org.wildfly.extras.creaper.core.online.operations.Values;
+
+public final class AddInvalidationCache extends AbstractAddCache {
+
+    private final Boolean asyncMarshalling;
+    private final CacheMode mode;
+    private final Long queueFlushInterval;
+    private final Long remoteTimeout;
+
+    public AddInvalidationCache(Builder builder) {
+        super(builder, CacheType.INVALIDATION_CACHE);
+        this.asyncMarshalling = builder.asyncMarshalling;
+        this.mode = builder.mode;
+        this.queueFlushInterval = builder.queueFlushInterval;
+        this.remoteTimeout = builder.remoteTimeout;
+    }
+
+    @Override
+    Values addValuesSpecificForCacheType(Values generalCacheValues) {
+        return generalCacheValues
+                .andOptional("async-marshalling", asyncMarshalling)
+                .andOptional("mode", mode != null ? mode.getMode() : null)
+                .andOptional("queue-flush-interval", queueFlushInterval)
+                .andOptional("remote-timeout", remoteTimeout);
+    }
+
+    public static final class Builder extends AbstractAddCache.Builder<Builder> {
+
+        public Builder(String name) {
+            super(name);
+        }
+
+        private Boolean asyncMarshalling;
+        private CacheMode mode;
+        private Long queueFlushInterval;
+        private Long remoteTimeout;
+
+        public Builder asyncMarshalling(Boolean asyncMarshalling) {
+            this.asyncMarshalling = asyncMarshalling;
+            return this;
+        }
+
+        public Builder mode(CacheMode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        public Builder queueFlushInterval(Long queueFlushInterval) {
+            this.queueFlushInterval = queueFlushInterval;
+            return this;
+        }
+
+        public Builder remoteTimeout(Long remoteTimeout) {
+            this.remoteTimeout = remoteTimeout;
+            return this;
+        }
+
+        public AddInvalidationCache build() {
+            return new AddInvalidationCache(this);
+        }
+
+    }
+
+}

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddLocalCache.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddLocalCache.java
@@ -1,0 +1,29 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import org.wildfly.extras.creaper.core.online.operations.Values;
+
+public final class AddLocalCache extends AbstractAddCache {
+
+
+    public AddLocalCache(Builder builder) {
+        super(builder, CacheType.LOCAL_CACHE);
+    }
+
+    @Override
+    Values addValuesSpecificForCacheType(Values generalCacheValues) {
+        return generalCacheValues;
+    }
+
+    public static final class Builder extends AbstractAddCache.Builder<Builder> {
+
+        public Builder(String name) {
+            super(name);
+        }
+
+        public AddLocalCache build() {
+            return new AddLocalCache(this);
+        }
+
+    }
+
+}

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddReplicatedCache.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddReplicatedCache.java
@@ -1,0 +1,66 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import org.wildfly.extras.creaper.core.online.operations.Values;
+
+public final class AddReplicatedCache extends AbstractAddCache {
+
+    private final Boolean asyncMarshalling;
+    private final CacheMode mode;
+    private final Long queueFlushInterval;
+    private final Long remoteTimeout;
+
+    public AddReplicatedCache(Builder builder) {
+        super(builder, CacheType.REPLICATED_CACHE);
+        this.asyncMarshalling = builder.asyncMarshalling;
+        this.mode = builder.mode;
+        this.queueFlushInterval = builder.queueFlushInterval;
+        this.remoteTimeout = builder.remoteTimeout;
+    }
+
+    @Override
+    Values addValuesSpecificForCacheType(Values generalCacheValues) {
+        return generalCacheValues
+                .andOptional("async-marshalling", asyncMarshalling)
+                .andOptional("mode", mode != null ? mode.getMode() : null)
+                .andOptional("queue-flush-interval", queueFlushInterval)
+                .andOptional("remote-timeout", remoteTimeout);
+    }
+
+    public static final class Builder extends AbstractAddCache.Builder<Builder> {
+
+        public Builder(String name) {
+            super(name);
+        }
+
+        private Boolean asyncMarshalling;
+        private CacheMode mode;
+        private Long queueFlushInterval;
+        private Long remoteTimeout;
+
+        public Builder asyncMarshalling(Boolean asyncMarshalling) {
+            this.asyncMarshalling = asyncMarshalling;
+            return this;
+        }
+
+        public Builder mode(CacheMode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        public Builder queueFlushInterval(Long queueFlushInterval) {
+            this.queueFlushInterval = queueFlushInterval;
+            return this;
+        }
+
+        public Builder remoteTimeout(Long remoteTimeout) {
+            this.remoteTimeout = remoteTimeout;
+            return this;
+        }
+
+        public AddReplicatedCache build() {
+            return new AddReplicatedCache(this);
+        }
+
+    }
+
+}

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/CacheMode.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/CacheMode.java
@@ -1,0 +1,18 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+public enum CacheMode {
+
+    SYNC("SYNC"),
+    ASYNC("ASYNC");
+
+    CacheMode(String mode) {
+        this.mode = mode;
+    }
+
+    private String mode;
+
+    public String getMode() {
+        return mode;
+    }
+
+}

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/CacheType.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/CacheType.java
@@ -1,0 +1,20 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+public enum CacheType {
+
+    DISTRIBUTED_CACHE("distributed-cache"),
+    INVALIDATION_CACHE("invalidation-cache"),
+    LOCAL_CACHE("local-cache"),
+    REPLICATED_CACHE("replicated-cache");
+
+    CacheType(String type) {
+        this.type = type;
+    }
+
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+}

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/ConsistentHashStrategy.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/ConsistentHashStrategy.java
@@ -1,0 +1,18 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+public enum ConsistentHashStrategy {
+
+    INTER_CACHE("INTER_CACHE"),
+    INTRA_CACHE("INTRA_CACHE");
+
+    ConsistentHashStrategy(String type) {
+        this.type = type;
+    }
+
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+}

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/RemoveCache.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/infinispan/cache/RemoveCache.java
@@ -1,0 +1,41 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import org.wildfly.extras.creaper.core.online.OnlineCommand;
+import org.wildfly.extras.creaper.core.online.OnlineCommandContext;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+
+public final class RemoveCache implements OnlineCommand {
+
+    private final String cacheContainer;
+    private final CacheType cacheType;
+    private final String cacheName;
+
+    private final Address address;
+
+    public RemoveCache(String cacheContainer,
+                       CacheType cacheType, String cacheName) {
+        if (cacheContainer == null) {
+            throw new IllegalArgumentException("Cache container is required");
+        }
+        if (cacheType == null) {
+            throw new IllegalArgumentException("Cache type is required");
+        }
+        if (cacheName == null) {
+            throw new IllegalArgumentException("Cache name is required");
+        }
+        this.cacheContainer = cacheContainer;
+        this.cacheType = cacheType;
+        this.cacheName = cacheName;
+        address = Address.subsystem("infinispan")
+                .and("cache-container", cacheContainer)
+                .and(cacheType.getType(), cacheName);
+    }
+
+    @Override
+    public void apply(OnlineCommandContext ctx) throws Exception {
+        Operations ops = new Operations(ctx.client);
+        ops.remove(address);
+    }
+
+}

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/ModelNodeResult.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/ModelNodeResult.java
@@ -160,6 +160,20 @@ public class ModelNodeResult extends ModelNode {
         return value().asString();
     }
 
+    public final double doubleValue() {
+        if (!hasDefinedValue()) {
+            throw new IllegalArgumentException();
+        }
+        return value().asDouble();
+    }
+
+    public final double doubleValue(double defaultValue) {
+        if (!hasDefinedValue()) {
+            return defaultValue;
+        }
+        return value().asDouble();
+    }
+
     public final List<ModelNode> listValue() {
         return value().asList();
     }
@@ -202,6 +216,20 @@ public class ModelNodeResult extends ModelNode {
     public final List<Long> longListValue(List<Long> defaultValue) {
         return hasDefinedValue() ? longListValue() : defaultValue;
     }
+
+    public final List<Double> doubleListValue() {
+        List<ModelNode> listValue = listValue();
+        List<Double> result = new ArrayList<Double>(listValue.size());
+        for (ModelNode value : listValue) {
+            result.add(value.asDouble());
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    public final List<Double> doubleListValue(List<Double> defaultValue) {
+        return hasDefinedValue() ? doubleListValue() : defaultValue;
+    }
+
 
     public final List<String> stringListValue() {
         List<ModelNode> listValue = listValue();

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Values.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Values.java
@@ -1,6 +1,7 @@
 package org.wildfly.extras.creaper.core.online.operations;
 
 import com.google.common.primitives.Booleans;
+import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import org.jboss.dmr.ModelNode;
@@ -77,6 +78,10 @@ public final class Values {
     }
 
     public static Values of(String name, long value) {
+        return EMPTY.and(name, value);
+    }
+
+    public static Values of(String name, double value) {
         return EMPTY.and(name, value);
     }
 
@@ -157,6 +162,12 @@ public final class Values {
         return new Values(newList);
     }
 
+    public Values and(String name, double value) {
+        List<Property> newList = new ArrayList<Property>(namedValues);
+        newList.add(new Property(name, new ModelNode(value)));
+        return new Values(newList);
+    }
+
     public Values and(String name, ModelNode value) {
         List<Property> newList = new ArrayList<Property>(namedValues);
         newList.add(new Property(name, value));
@@ -184,6 +195,11 @@ public final class Values {
     }
 
     public Values andOptional(String name, ModelNode value) {
+        if (value == null) return this;
+        return and(name, value);
+    }
+
+    public Values andOptional(String name, Double value) {
         if (value == null) return this;
         return and(name, value);
     }
@@ -243,9 +259,21 @@ public final class Values {
         return new Values(newList);
     }
 
+    public Values andList(String name, double... value) {
+        ModelNode listValue = new ModelNode().setEmptyList();
+        for (double singleValue : value) {
+            listValue.add(singleValue);
+        }
+
+        List<Property> newList = new ArrayList<Property>(namedValues);
+        newList.add(new Property(name, listValue));
+        return new Values(newList);
+    }
+
     /**
      * @param clazz type of elements in the {@code value} list; must be one of {@code Boolean.class},
-     * {@code Integer.class}, {@code Long.class}, {@code String.class} or {@code ModelNode.class}
+     * {@code Integer.class}, {@code Long.class}, {@code Double.class}, {@code String.class}
+     * or {@code ModelNode.class}
      * @throws IllegalArgumentException if {@code clazz} is not one of the known types
      * @throws ClassCastException if some elements of the {@code value} list are not of type {@code clazz}
      * @throws ArrayStoreException if some elements of the {@code value} list are not of type {@code clazz}
@@ -260,10 +288,13 @@ public final class Values {
             return andList(name, Longs.toArray((List<Long>) value));
         } else if (clazz == String.class) {
             return andList(name, value.toArray(new String[value.size()]));
-        } else if (clazz == ModelNode.class) {
+        } else if (clazz == Double.class) {
+            return andList(name, Doubles.toArray((List<Double>) value));
+        }  else if (clazz == ModelNode.class) {
             return andList(name, value.toArray(new ModelNode[value.size()]));
         } else {
-            throw new IllegalArgumentException("Only List<Boolean>, List<Integer>, List<Long>, List<String> and List<ModelNode> are supported");
+            throw new IllegalArgumentException("Only List<Boolean>, List<Integer>, List<Long>, List<Double>, "
+                    + "List<String> and List<ModelNode> are supported");
         }
     }
 

--- a/core/src/test/java/org/wildfly/extras/creaper/core/online/ModelNodeResultTest.java
+++ b/core/src/test/java/org/wildfly/extras/creaper/core/online/ModelNodeResultTest.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Collections;
 
+import com.google.common.primitives.Doubles;
+
+import static org.junit.Assert.assertArrayEquals;
 import static org.wildfly.extras.creaper.core.online.ModelNodeConstants.BATCH_RESULT;
 import static org.wildfly.extras.creaper.core.online.ModelNodeConstants.DEFINED_RESULT_BOOLEAN;
 import static org.wildfly.extras.creaper.core.online.ModelNodeConstants.DEFINED_RESULT_LIST_BOOLEAN;
@@ -136,6 +139,7 @@ public class ModelNodeResultTest {
         assertEquals(13, result.intValue(42));
         assertEquals(13L, result.longValue(42L));
         assertEquals("13", result.stringValue("42"));
+        assertEquals(13.0, result.doubleValue(23.8), 0.00000001);
     }
 
     @Test
@@ -151,6 +155,8 @@ public class ModelNodeResultTest {
         assertEquals(Collections.singletonList(13), result.intListValue(Collections.singletonList(42)));
         assertEquals(Collections.singletonList(13L), result.longListValue(Collections.singletonList(42L)));
         assertEquals(Collections.singletonList("13"), result.stringListValue(Collections.singletonList("42")));
+        assertArrayEquals(new double[] {13.0},
+                Doubles.toArray(result.doubleListValue(Collections.singletonList(42.0))), 0.000001);
     }
 
     @Test
@@ -197,11 +203,17 @@ public class ModelNodeResultTest {
             fail();
         } catch (IllegalArgumentException ignored) {
         }
+        try {
+            result.doubleValue();
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
 
         assertEquals(true, result.booleanValue(true));
         assertEquals(42, result.intValue(42));
         assertEquals(42L, result.longValue(42L));
         assertEquals("42", result.stringValue("42"));
+        assertEquals(1.667, result.doubleValue(1.667), 0.000001);
         assertEquals(Collections.<Boolean>emptyList(), result.booleanListValue(Collections.<Boolean>emptyList()));
         assertEquals(Collections.<Integer>emptyList(), result.intListValue(Collections.<Integer>emptyList()));
         assertEquals(Collections.<Long>emptyList(), result.longListValue(Collections.<Long>emptyList()));
@@ -210,6 +222,8 @@ public class ModelNodeResultTest {
         assertEquals(Collections.singletonList(42), result.intListValue(Collections.singletonList(42)));
         assertEquals(Collections.singletonList(42L), result.longListValue(Collections.singletonList(42L)));
         assertEquals(Collections.singletonList("42"), result.stringListValue(Collections.singletonList("42")));
+        assertArrayEquals(new double[] {42.0},
+                Doubles.toArray(result.doubleListValue(Collections.singletonList(42.0))), 0.000001);
     }
 
     @Test

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddDistributedCacheOnlineTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddDistributedCacheOnlineTest.java
@@ -1,0 +1,96 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.ServerVersion;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineOptions;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class AddDistributedCacheOnlineTest {
+
+    private OnlineManagementClient client;
+    private Operations ops;
+
+    private static final String TEST_CACHE_NAME = UUID.randomUUID().toString();
+
+    private static final Address TEST_CACHE_ADDRESS = Address
+            .subsystem("infinispan")
+            .and("cache-container", "hibernate")
+            .and("distributed-cache", TEST_CACHE_NAME);
+
+    @Before
+    public void connect() throws Exception {
+        client = ManagementClient.online(OnlineOptions.standalone().localDefault().build());
+        ops = new Operations(client);
+    }
+
+    @After
+    public void after() throws CommandFailedException, IOException, OperationException {
+        client.apply(new RemoveCache("hibernate", CacheType.DISTRIBUTED_CACHE, TEST_CACHE_NAME));
+        client.close();
+    }
+
+    @Test
+    public void addCacheWithRequiredArgsOnly() throws CommandFailedException, IOException {
+        AddDistributedCache cmd = new AddDistributedCache.Builder(TEST_CACHE_NAME)
+                .cacheContainer("hibernate")
+                .mode(CacheMode.SYNC)
+                .build();
+        client.apply(cmd);
+        final ModelNodeResult resource = ops.readResource(TEST_CACHE_ADDRESS);
+        Assert.assertTrue(resource.isSuccess());
+        Assert.assertEquals("SYNC", ops.readAttribute(TEST_CACHE_ADDRESS, "mode").stringValue());
+    }
+
+    @Test
+    public void addCacheWithMoreArgs() throws CommandFailedException, IOException {
+        AddDistributedCache cmd = new AddDistributedCache.Builder(TEST_CACHE_NAME)
+                .cacheContainer("hibernate")
+                .mode(CacheMode.SYNC)
+                .asyncMarshalling(true)
+                .queueFlushInterval(1234L)
+                .remoteTimeout(4321L)
+                .statisticsEnabled(false)
+                .capacityFactor(1.47)
+                .consistentHashStrategy(ConsistentHashStrategy.INTER_CACHE)
+                .l1lifespan(1780L)
+                .owners(3)
+                .segments(74)
+                .build();
+        client.apply(cmd);
+        final ModelNodeResult resource = ops.readResource(TEST_CACHE_ADDRESS);
+        Assert.assertTrue(resource.isSuccess());
+        Assert.assertEquals(CacheMode.SYNC.getMode(), ops.readAttribute(TEST_CACHE_ADDRESS, "mode").stringValue());
+        Assert.assertEquals(true, ops.readAttribute(TEST_CACHE_ADDRESS, "async-marshalling").booleanValue());
+        Assert.assertEquals(1234L, ops.readAttribute(TEST_CACHE_ADDRESS, "queue-flush-interval").longValue());
+        Assert.assertEquals(4321L, ops.readAttribute(TEST_CACHE_ADDRESS, "remote-timeout").longValue());
+        Assert.assertEquals(false,
+                ops.readAttribute(TEST_CACHE_ADDRESS, "statistics-enabled").booleanValue());
+        Assert.assertEquals(1780L, ops.readAttribute(TEST_CACHE_ADDRESS, "l1-lifespan").longValue());
+        Assert.assertEquals(3, ops.readAttribute(TEST_CACHE_ADDRESS, "owners").intValue());
+        Assert.assertEquals(74, ops.readAttribute(TEST_CACHE_ADDRESS, "segments").intValue());
+        if (client.version().greaterThanOrEqualTo(ServerVersion.VERSION_3_0_0)) {  // wildfly 9+ only
+            Assert.assertEquals(1.47, ops.readAttribute(TEST_CACHE_ADDRESS, "capacity-factor").doubleValue(),
+                    0.001);
+            Assert.assertEquals(ConsistentHashStrategy.INTER_CACHE.getType(),
+                    ops.readAttribute(TEST_CACHE_ADDRESS, "consistent-hash-strategy").stringValue());
+        }
+    }
+
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddInvalidationCacheOnlineTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddInvalidationCacheOnlineTest.java
@@ -1,0 +1,81 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineOptions;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class AddInvalidationCacheOnlineTest {
+
+    private OnlineManagementClient client;
+    private Operations ops;
+
+    private static final String TEST_CACHE_NAME = UUID.randomUUID().toString();
+
+    private static final Address TEST_CACHE_ADDRESS = Address
+            .subsystem("infinispan")
+            .and("cache-container", "hibernate")
+            .and("invalidation-cache", TEST_CACHE_NAME);
+
+    @Before
+    public void connect() throws Exception {
+        client = ManagementClient.online(OnlineOptions.standalone().localDefault().build());
+        ops = new Operations(client);
+    }
+
+    @After
+    public void after() throws CommandFailedException, IOException, OperationException {
+        client.apply(new RemoveCache("hibernate", CacheType.INVALIDATION_CACHE, TEST_CACHE_NAME));
+        client.close();
+    }
+
+    @Test
+    public void addCacheWithRequiredArgsOnly() throws CommandFailedException, IOException {
+        AddInvalidationCache cmd = new AddInvalidationCache.Builder(TEST_CACHE_NAME)
+                .cacheContainer("hibernate")
+                .mode(CacheMode.SYNC)
+                .build();
+        client.apply(cmd);
+        final ModelNodeResult resource = ops.readResource(TEST_CACHE_ADDRESS);
+        Assert.assertTrue(resource.isSuccess());
+        Assert.assertEquals("SYNC", ops.readAttribute(TEST_CACHE_ADDRESS, "mode").stringValue());
+    }
+
+    @Test
+    public void addCacheWithMoreArgs() throws CommandFailedException, IOException {
+        AddInvalidationCache cmd = new AddInvalidationCache.Builder(TEST_CACHE_NAME)
+                .cacheContainer("hibernate")
+                .mode(CacheMode.SYNC)
+                .asyncMarshalling(true)
+                .queueFlushInterval(1234L)
+                .remoteTimeout(4321L)
+                .statisticsEnabled(false)
+                .build();
+        client.apply(cmd);
+        final ModelNodeResult resource = ops.readResource(TEST_CACHE_ADDRESS);
+        Assert.assertTrue(resource.isSuccess());
+        Assert.assertEquals(CacheMode.SYNC.getMode(), ops.readAttribute(TEST_CACHE_ADDRESS, "mode").stringValue());
+        Assert.assertEquals(true, ops.readAttribute(TEST_CACHE_ADDRESS, "async-marshalling").booleanValue());
+        Assert.assertEquals(1234L, ops.readAttribute(TEST_CACHE_ADDRESS, "queue-flush-interval").longValue());
+        Assert.assertEquals(4321L, ops.readAttribute(TEST_CACHE_ADDRESS, "remote-timeout").longValue());
+        Assert.assertEquals(false,
+                ops.readAttribute(TEST_CACHE_ADDRESS, "statistics-enabled").booleanValue());
+    }
+
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddLocalCacheOnlineTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddLocalCacheOnlineTest.java
@@ -1,0 +1,78 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineOptions;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class AddLocalCacheOnlineTest {
+
+    private OnlineManagementClient client;
+    private Operations ops;
+
+    private static final String TEST_CACHE_NAME = UUID.randomUUID().toString();
+
+    private static final Address TEST_CACHE_ADDRESS = Address
+            .subsystem("infinispan")
+            .and("cache-container", "hibernate")
+            .and("local-cache", TEST_CACHE_NAME);
+
+    @Before
+    public void connect() throws Exception {
+        client = ManagementClient.online(OnlineOptions.standalone().localDefault().build());
+        ops = new Operations(client);
+    }
+
+    @After
+    public void after() throws CommandFailedException, IOException, OperationException {
+        client.apply(new RemoveCache("hibernate", CacheType.LOCAL_CACHE, TEST_CACHE_NAME));
+        client.close();
+    }
+
+    @Test
+    public void addCacheWithRequiredArgsOnly() throws CommandFailedException, IOException {
+        AddLocalCache cmd = new AddLocalCache.Builder(TEST_CACHE_NAME)
+                .cacheContainer("hibernate")
+                .build();
+        client.apply(cmd);
+        final ModelNodeResult resource = ops.readResource(TEST_CACHE_ADDRESS);
+        Assert.assertTrue(resource.isSuccess());
+    }
+
+    @Test
+    public void addCacheWithMoreArgs() throws CommandFailedException, IOException {
+        final String jndiName = "java:/MyAwesomeCache";
+        final String module = "org.jboss.awesome";
+        AddLocalCache cmd = new AddLocalCache.Builder(TEST_CACHE_NAME)
+                .cacheContainer("hibernate")
+                .statisticsEnabled(false)
+                .jndiName(jndiName)
+                .module(module)
+                .build();
+        client.apply(cmd);
+        final ModelNodeResult resource = ops.readResource(TEST_CACHE_ADDRESS);
+        Assert.assertTrue(resource.isSuccess());
+        Assert.assertEquals(jndiName, ops.readAttribute(TEST_CACHE_ADDRESS, "jndi-name").stringValue());
+        Assert.assertEquals(module, ops.readAttribute(TEST_CACHE_ADDRESS, "module").stringValue());
+        Assert.assertEquals(false,
+                ops.readAttribute(TEST_CACHE_ADDRESS, "statistics-enabled").booleanValue());
+    }
+
+
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddReplicatedCacheOnlineTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/infinispan/cache/AddReplicatedCacheOnlineTest.java
@@ -1,0 +1,81 @@
+package org.wildfly.extras.creaper.commands.infinispan.cache;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineOptions;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class AddReplicatedCacheOnlineTest {
+
+    private OnlineManagementClient client;
+    private Operations ops;
+
+    private static final String TEST_CACHE_NAME = UUID.randomUUID().toString();
+
+    private static final Address TEST_CACHE_ADDRESS = Address
+            .subsystem("infinispan")
+            .and("cache-container", "hibernate")
+            .and("replicated-cache", TEST_CACHE_NAME);
+
+    @Before
+    public void connect() throws Exception {
+        client = ManagementClient.online(OnlineOptions.standalone().localDefault().build());
+        ops = new Operations(client);
+    }
+
+    @After
+    public void after() throws CommandFailedException, IOException, OperationException {
+        client.apply(new RemoveCache("hibernate", CacheType.REPLICATED_CACHE, TEST_CACHE_NAME));
+        client.close();
+    }
+
+    @Test
+    public void addCacheWithRequiredArgsOnly() throws CommandFailedException, IOException {
+        AddReplicatedCache cmd = new AddReplicatedCache.Builder(TEST_CACHE_NAME)
+                .cacheContainer("hibernate")
+                .mode(CacheMode.SYNC)
+                .build();
+        client.apply(cmd);
+        final ModelNodeResult resource = ops.readResource(TEST_CACHE_ADDRESS);
+        Assert.assertTrue(resource.isSuccess());
+        Assert.assertEquals("SYNC", ops.readAttribute(TEST_CACHE_ADDRESS, "mode").stringValue());
+    }
+
+    @Test
+    public void addCacheWithMoreArgs() throws CommandFailedException, IOException {
+        AddReplicatedCache cmd = new AddReplicatedCache.Builder(TEST_CACHE_NAME)
+                .cacheContainer("hibernate")
+                .mode(CacheMode.SYNC)
+                .asyncMarshalling(true)
+                .queueFlushInterval(1234L)
+                .remoteTimeout(4321L)
+                .statisticsEnabled(false)
+                .build();
+        client.apply(cmd);
+        final ModelNodeResult resource = ops.readResource(TEST_CACHE_ADDRESS);
+        Assert.assertTrue(resource.isSuccess());
+        Assert.assertEquals(CacheMode.SYNC.getMode(), ops.readAttribute(TEST_CACHE_ADDRESS, "mode").stringValue());
+        Assert.assertEquals(true, ops.readAttribute(TEST_CACHE_ADDRESS, "async-marshalling").booleanValue());
+        Assert.assertEquals(1234L, ops.readAttribute(TEST_CACHE_ADDRESS, "queue-flush-interval").longValue());
+        Assert.assertEquals(4321L, ops.readAttribute(TEST_CACHE_ADDRESS, "remote-timeout").longValue());
+        Assert.assertEquals(false,
+                ops.readAttribute(TEST_CACHE_ADDRESS, "statistics-enabled").booleanValue());
+    }
+
+}


### PR DESCRIPTION
This also adds support for Double in Values and ModelNodeResult, because it is needed for some properties of distributed caches.

Offline version of commands... Ugh, maybe later, aligator.