### PR TITLE
add ReloadToSnapshot

### DIFF
--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/CommonRestartOperation.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/CommonRestartOperation.java
@@ -1,0 +1,49 @@
+package org.wildfly.extras.creaper.core.online.operations.admin;
+
+import org.wildfly.extras.creaper.core.online.Constants;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.Values;
+
+import java.io.IOException;
+
+enum CommonRestartOperation implements RestartOperation {
+    RELOAD {
+        @Override
+        public boolean isRequired(ModelNodeResult serverStateResult, boolean isManagedServerInDomain) {
+            if (isManagedServerInDomain) {
+                // reloading an individual server in managed domain is not supported on AS 7, so when trying to figure
+                // out if reload of host in domain is required, some servers on that host might actually signal
+                // "restart required" (even if it would be "reload required" in the same situation in standalone);
+                // this is also true even on WildFly, which supports reloading a server in domain (see WFLY-351)
+                //
+                // anyway, reloading a host means restarting all its servers, so returning true is fine in this case
+                if (Constants.CONTROLLER_PROCESS_STATE_RESTART_REQUIRED.equals(serverStateResult.stringValue())) {
+                    return true;
+                }
+            }
+
+            return Constants.CONTROLLER_PROCESS_STATE_RELOAD_REQUIRED.equals(serverStateResult.stringValue());
+        }
+
+        @Override
+        public ModelNodeResult perform(Operations ops, Address address) throws IOException {
+            return ops.invoke(Constants.RELOAD, address);
+        }
+    },
+    RESTART {
+        @Override
+        public boolean isRequired(ModelNodeResult serverStateResult, boolean isManagedServerInDomain) {
+            serverStateResult.assertDefinedValue();
+            return Constants.CONTROLLER_PROCESS_STATE_RESTART_REQUIRED.equals(serverStateResult.stringValue());
+        }
+
+        @Override
+        public ModelNodeResult perform(Operations ops, Address address) throws IOException {
+            return ops.invoke(Constants.SHUTDOWN, address, Values.of(Constants.RESTART, true));
+        }
+    };
+
+    abstract boolean isRequired(ModelNodeResult serverStateResult, boolean isManagedServerInDomain);
+}

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/DomainAdministration.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/DomainAdministration.java
@@ -107,7 +107,7 @@ public final class DomainAdministration extends Administration {
      * requires reload). This is a variant of {@link Administration#isReloadRequired()}.
      */
     public boolean isReloadRequired(String host) throws IOException {
-        return domainOps.isRestartOperationRequired(host, RestartOperation.RELOAD);
+        return domainOps.isRestartOperationRequired(host, CommonRestartOperation.RELOAD);
     }
 
     /**
@@ -115,7 +115,7 @@ public final class DomainAdministration extends Administration {
      * This is a variant of {@link Administration#reload()}.
      */
     public void reload(String host) throws IOException, InterruptedException, TimeoutException {
-        domainOps.performRestartOperation(host, RestartOperation.RELOAD);
+        domainOps.performRestartOperation(host, CommonRestartOperation.RELOAD);
     }
 
     /**
@@ -123,7 +123,7 @@ public final class DomainAdministration extends Administration {
      * This is a variant of {@link Administration#reloadIfRequired()}.
      */
     public boolean reloadIfRequired(String host) throws IOException, InterruptedException, TimeoutException {
-        if (domainOps.isRestartOperationRequired(host, RestartOperation.RELOAD)) {
+        if (domainOps.isRestartOperationRequired(host, CommonRestartOperation.RELOAD)) {
             reload(host);
             return true;
         }
@@ -137,17 +137,17 @@ public final class DomainAdministration extends Administration {
      * requires restart). This is a variant of {@link Administration#isRestartRequired()}.
      */
     public boolean isRestartRequired(String host) throws IOException {
-        return domainOps.isRestartOperationRequired(host, RestartOperation.RESTART);
+        return domainOps.isRestartOperationRequired(host, CommonRestartOperation.RESTART);
     }
 
     /** Restarts given {@code host}. This is a variant of {@link Administration#restart()}. */
     public void restart(String host) throws IOException, InterruptedException, TimeoutException {
-        domainOps.performRestartOperation(host, RestartOperation.RESTART);
+        domainOps.performRestartOperation(host, CommonRestartOperation.RESTART);
     }
 
     /** Restarts given {@code host} if required. This is a variant of {@link Administration#restartIfRequired()}. */
     public boolean restartIfRequired(String host) throws IOException, InterruptedException, TimeoutException {
-        if (domainOps.isRestartOperationRequired(host, RestartOperation.RESTART)) {
+        if (domainOps.isRestartOperationRequired(host, CommonRestartOperation.RESTART)) {
             restart(host);
             return true;
         }

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/DomainAdministrationOperations.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/DomainAdministrationOperations.java
@@ -29,17 +29,17 @@ final class DomainAdministrationOperations implements AdministrationOperations {
 
     @Override
     public boolean isReloadRequired() throws IOException {
-        return isRestartOperationRequired(client.options().defaultHost, RestartOperation.RELOAD);
+        return isRestartOperationRequired(client.options().defaultHost, CommonRestartOperation.RELOAD);
     }
 
     @Override
     public void reload() throws IOException, InterruptedException, TimeoutException {
-        performRestartOperation(client.options().defaultHost, RestartOperation.RELOAD);
+        performRestartOperation(client.options().defaultHost, CommonRestartOperation.RELOAD);
     }
 
     @Override
     public boolean reloadIfRequired() throws IOException, InterruptedException, TimeoutException {
-        if (isRestartOperationRequired(client.options().defaultHost, RestartOperation.RELOAD)) {
+        if (isRestartOperationRequired(client.options().defaultHost, CommonRestartOperation.RELOAD)) {
             reload();
             return true;
         }
@@ -50,17 +50,17 @@ final class DomainAdministrationOperations implements AdministrationOperations {
 
     @Override
     public boolean isRestartRequired() throws IOException {
-        return isRestartOperationRequired(client.options().defaultHost, RestartOperation.RESTART);
+        return isRestartOperationRequired(client.options().defaultHost, CommonRestartOperation.RESTART);
     }
 
     @Override
     public void restart() throws IOException, InterruptedException, TimeoutException {
-        performRestartOperation(client.options().defaultHost, RestartOperation.RESTART);
+        performRestartOperation(client.options().defaultHost, CommonRestartOperation.RESTART);
     }
 
     @Override
     public boolean restartIfRequired() throws IOException, InterruptedException, TimeoutException {
-        if (isRestartOperationRequired(client.options().defaultHost, RestartOperation.RESTART)) {
+        if (isRestartOperationRequired(client.options().defaultHost, CommonRestartOperation.RESTART)) {
             restart();
             return true;
         }
@@ -113,7 +113,7 @@ final class DomainAdministrationOperations implements AdministrationOperations {
         waitUntilServersAreRunning(host, allServers, needsToReconnect);
     }
 
-    boolean isRestartOperationRequired(String host, RestartOperation restartOperation) throws IOException {
+    boolean isRestartOperationRequired(String host, CommonRestartOperation restartOperation) throws IOException {
         List<String> allServers = allRunningServers(host);
 
         Batch batch = new Batch();

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/ReloadToOriginal.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/ReloadToOriginal.java
@@ -6,6 +6,7 @@ import org.wildfly.extras.creaper.core.online.ModelNodeResult;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.Address;
 import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.Values;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
@@ -46,7 +47,7 @@ public final class ReloadToOriginal {
     // - the checkReloadToOriginalMakesSense method is ready
     // - the perform method is almost ready, need to add a call to DomainAdministrationOperations
     // - need to add a perform(String host) method variant that would be specific to managed domain
-    // - need to change RestartOperation.RELOAD_TO_ORIGINAL -- I currently don't know how exactly,
+    // - need to change ReloadToOriginalRestartOperation -- I currently don't know how exactly,
     //   and a bigger refactoring will likely be required
 
     /**
@@ -106,6 +107,14 @@ public final class ReloadToOriginal {
         checkReloadToOriginalMakesSense(client, null);
 
         new StandaloneAdministrationOperations(client, timeoutInSeconds)
-                .performRestartOperation(RestartOperation.RELOAD_TO_ORIGINAL);
+                .performRestartOperation(new ReloadToOriginalRestartOperation());
+    }
+
+    private static final class ReloadToOriginalRestartOperation implements RestartOperation {
+        @Override
+        public ModelNodeResult perform(Operations ops, Address address) throws IOException {
+            // only works for standalone servers
+            return ops.invoke(Constants.RELOAD, address, Values.of(Constants.USE_CURRENT_SERVER_CONFIG, false));
+        }
     }
 }

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/ReloadToSnapshot.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/ReloadToSnapshot.java
@@ -1,0 +1,73 @@
+package org.wildfly.extras.creaper.core.online.operations.admin;
+
+import org.wildfly.extras.creaper.core.ServerVersion;
+import org.wildfly.extras.creaper.core.online.Constants;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.Values;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * <p>Utility for reloading the server to a snapshot. This requires WildFly Core 3.</p>
+ */
+public final class ReloadToSnapshot {
+    private final OnlineManagementClient client;
+    private final String snapshot;
+    private final int timeoutInSeconds;
+
+    public ReloadToSnapshot(OnlineManagementClient client, String snapshot) throws IOException {
+        this(client, snapshot, Administration.DEFAULT_TIMEOUT);
+    }
+
+    public ReloadToSnapshot(OnlineManagementClient client, String snapshot, int timeoutInSeconds) throws IOException {
+        if (client.version().lessThan(ServerVersion.VERSION_5_0_0)) {
+            throw new IllegalStateException("ReloadToSnapshot requires at least WildFly Core 3.");
+        }
+
+        this.client = client;
+        this.snapshot = snapshot;
+        this.timeoutInSeconds = timeoutInSeconds;
+    }
+
+    /**
+     * Reload the server to a snapshot. In managed domain, reloads the default host.
+     */
+    public void perform() throws InterruptedException, TimeoutException, IOException {
+        if (client.options().isStandalone) {
+            new StandaloneAdministrationOperations(client, timeoutInSeconds)
+                    .performRestartOperation(new ReloadToSnapshotRestartOperation(snapshot));
+        } else {
+            perform(client.options().defaultHost);
+        }
+    }
+
+    /**
+     * Reload given {@code host} to a snapshot. This method only makes sense in managed domain.
+     */
+    public void perform(String host) throws InterruptedException, TimeoutException, IOException {
+        if (!client.options().isDomain) {
+            throw new IllegalStateException("Asked to reload host '" + host
+                    + "' to a snapshot, but the server isn't a domain controller");
+        }
+
+        new DomainAdministrationOperations(client, timeoutInSeconds)
+                .performRestartOperation(host, new ReloadToSnapshotRestartOperation(snapshot));
+    }
+
+    private static final class ReloadToSnapshotRestartOperation implements RestartOperation {
+        private final String snapshot;
+
+        ReloadToSnapshotRestartOperation(String snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public ModelNodeResult perform(Operations ops, Address address) throws IOException {
+            return ops.invoke(Constants.RELOAD, address, Values.of(Constants.SERVER_CONFIG, snapshot));
+        }
+    }
+}

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/RestartOperation.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/RestartOperation.java
@@ -1,64 +1,11 @@
 package org.wildfly.extras.creaper.core.online.operations.admin;
 
-import org.wildfly.extras.creaper.core.online.Constants;
 import org.wildfly.extras.creaper.core.online.ModelNodeResult;
 import org.wildfly.extras.creaper.core.online.operations.Address;
 import org.wildfly.extras.creaper.core.online.operations.Operations;
-import org.wildfly.extras.creaper.core.online.operations.Values;
 
 import java.io.IOException;
 
-enum RestartOperation {
-    RELOAD {
-        @Override
-        boolean isRequired(ModelNodeResult serverStateResult, boolean isManagedServerInDomain) {
-            if (isManagedServerInDomain) {
-                // reloading an individual server in managed domain is not supported on AS 7, so when trying to figure
-                // out if reload of host in domain is required, some servers on that host might actually signal
-                // "restart required" (even if it would be "reload required" in the same situation in standalone);
-                // this is also true even on WildFly, which supports reloading a server in domain (see WFLY-351)
-                //
-                // anyway, reloading a host means restarting all its servers, so returning true is fine in this case
-                if (Constants.CONTROLLER_PROCESS_STATE_RESTART_REQUIRED.equals(serverStateResult.stringValue())) {
-                    return true;
-                }
-            }
-
-            return Constants.CONTROLLER_PROCESS_STATE_RELOAD_REQUIRED.equals(serverStateResult.stringValue());
-        }
-
-        @Override
-        ModelNodeResult perform(Operations ops, Address address) throws IOException {
-            return ops.invoke(Constants.RELOAD, address);
-        }
-    },
-    RELOAD_TO_ORIGINAL {
-        @Override
-        boolean isRequired(ModelNodeResult serverStateResult, boolean isManagedServerInDomain) {
-            // there's no such thing as ReloadToOriginal.performIfRequired
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        ModelNodeResult perform(Operations ops, Address address) throws IOException {
-            // only works for standalone servers
-            return ops.invoke(Constants.RELOAD, address, Values.of(Constants.USE_CURRENT_SERVER_CONFIG, false));
-        }
-    },
-    RESTART {
-        @Override
-        boolean isRequired(ModelNodeResult serverStateResult, boolean isManagedServerInDomain) {
-            serverStateResult.assertDefinedValue();
-            return Constants.CONTROLLER_PROCESS_STATE_RESTART_REQUIRED.equals(serverStateResult.stringValue());
-        }
-
-        @Override
-        ModelNodeResult perform(Operations ops, Address address) throws IOException {
-            return ops.invoke(Constants.SHUTDOWN, address, Values.of(Constants.RESTART, true));
-        }
-    };
-
-    abstract boolean isRequired(ModelNodeResult serverStateResult, boolean isManagedServerInDomain);
-
-    abstract ModelNodeResult perform(Operations ops, Address address) throws IOException;
+interface RestartOperation {
+    ModelNodeResult perform(Operations ops, Address address) throws IOException;
 }

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/StandaloneAdministrationOperations.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/StandaloneAdministrationOperations.java
@@ -25,15 +25,15 @@ final class StandaloneAdministrationOperations implements AdministrationOperatio
     // ---
 
     public boolean isReloadRequired() throws IOException {
-        return isRestartOperationRequired(RestartOperation.RELOAD);
+        return isRestartOperationRequired(CommonRestartOperation.RELOAD);
     }
 
     public void reload() throws IOException, InterruptedException, TimeoutException {
-        performRestartOperation(RestartOperation.RELOAD);
+        performRestartOperation(CommonRestartOperation.RELOAD);
     }
 
     public boolean reloadIfRequired() throws IOException, InterruptedException, TimeoutException {
-        if (isRestartOperationRequired(RestartOperation.RELOAD)) {
+        if (isRestartOperationRequired(CommonRestartOperation.RELOAD)) {
             reload();
             return true;
         }
@@ -44,15 +44,15 @@ final class StandaloneAdministrationOperations implements AdministrationOperatio
 
     @Override
     public boolean isRestartRequired() throws IOException {
-        return isRestartOperationRequired(RestartOperation.RESTART);
+        return isRestartOperationRequired(CommonRestartOperation.RESTART);
     }
 
     public void restart() throws IOException, InterruptedException, TimeoutException {
-        performRestartOperation(RestartOperation.RESTART);
+        performRestartOperation(CommonRestartOperation.RESTART);
     }
 
     public boolean restartIfRequired() throws IOException, InterruptedException, TimeoutException {
-        if (isRestartOperationRequired(RestartOperation.RESTART)) {
+        if (isRestartOperationRequired(CommonRestartOperation.RESTART)) {
             restart();
             return true;
         }
@@ -93,7 +93,7 @@ final class StandaloneAdministrationOperations implements AdministrationOperatio
         waitUntilServerIsRunning(needsToReconnect);
     }
 
-    private boolean isRestartOperationRequired(RestartOperation restartOperation) throws IOException {
+    private boolean isRestartOperationRequired(CommonRestartOperation restartOperation) throws IOException {
         return restartOperation.isRequired(ops.readAttribute(Address.root(), Constants.SERVER_STATE), false);
     }
 


### PR DESCRIPTION
This commit adds a new class ReloadToSnapshot that supports
reloading the server to a given snapshot. The feature itself
only exists in WildFly Core 3, though.

Small refactoring of the RestartOperation enum was required,
which also lead to a small improvement in ReloadToOriginal.