### PR TITLE
Retrieve last value in address

### DIFF
--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Address.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/Address.java
@@ -9,7 +9,8 @@ import java.util.List;
 
 /**
  * <p>An address in the management tree. It is a sequence of string pairs ({@code key=value}), possibly empty. This
- * class is immutable and its only public API consists of various ways of <i>creating</i> an address.</p>
+ * class is immutable and its only public API consists of various ways of <i>creating</i> an address and method for
+ * retrieving last pair value (which is useful as the last value usually represents the final element name).</p>
  *
  * <p>There are some factory methods for obtaining an initial address:</p>
  * <ul>
@@ -77,6 +78,18 @@ public final class Address {
             result.add(pair.key, pair.value);
         }
         return result;
+    }
+
+    /**
+     * @return value of the last pair in the string sequence or null in case it is only root address.
+     */
+    public String getLastPairValue() {
+        if (address.isEmpty()) {
+            return null;
+        } else {
+            StringPair last = address.get(address.size() - 1);
+            return last.value;
+        }
     }
 
     @Override

--- a/core/src/test/java/org/wildfly/extras/creaper/core/online/operations/AddressTest.java
+++ b/core/src/test/java/org/wildfly/extras/creaper/core/online/operations/AddressTest.java
@@ -2,11 +2,12 @@ package org.wildfly.extras.creaper.core.online.operations;
 
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.wildfly.extras.creaper.core.online.Constants;
 import org.junit.Test;
+import org.wildfly.extras.creaper.core.online.Constants;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class AddressTest {
@@ -20,6 +21,7 @@ public class AddressTest {
         assertFalse(modelNode.hasDefined(0));
 
         assertEquals("/", emptyAddress.toString());
+        assertNull(emptyAddress.getLastPairValue());
     }
 
     @Test
@@ -39,6 +41,7 @@ public class AddressTest {
         assertEquals("b", firstElement.asProperty().getValue().asString());
 
         assertEquals("/a=b", singleElementAddress.toString());
+        assertEquals("b", singleElementAddress.getLastPairValue());
     }
 
     @Test
@@ -65,6 +68,7 @@ public class AddressTest {
         assertEquals("d", secondElement.asProperty().getValue().asString());
 
         assertEquals("/a=b/c=d", twoElementsAddress.toString());
+        assertEquals("d", twoElementsAddress.getLastPairValue());
     }
 
     @Test
@@ -84,6 +88,7 @@ public class AddressTest {
         assertEquals("org.jboss.as.logging", firstElement.asProperty().getValue().asString());
 
         assertEquals("/extension=org.jboss.as.logging", singleElementAddress.toString());
+        assertEquals("org.jboss.as.logging", singleElementAddress.getLastPairValue());
     }
 
     @Test
@@ -103,6 +108,7 @@ public class AddressTest {
         assertEquals("master", firstElement.asProperty().getValue().asString());
 
         assertEquals("/host=master", singleElementAddress.toString());
+        assertEquals("master", singleElementAddress.getLastPairValue());
     }
 
     @Test
@@ -122,6 +128,7 @@ public class AddressTest {
         assertEquals("foo", firstElement.asProperty().getValue().asString());
 
         assertEquals("/subsystem=foo", singleElementAddress.toString());
+        assertEquals("foo", singleElementAddress.getLastPairValue());
     }
 
     @Test
@@ -141,6 +148,7 @@ public class AddressTest {
         assertEquals("management", firstElement.asProperty().getValue().asString());
 
         assertEquals("/core-service=management", singleElementAddress.toString());
+        assertEquals("management", singleElementAddress.getLastPairValue());
     }
 
     @Test
@@ -160,5 +168,6 @@ public class AddressTest {
         assertEquals("simple.war", firstElement.asProperty().getValue().asString());
 
         assertEquals("/deployment=simple.war", singleElementAddress.toString());
+        assertEquals("simple.war", singleElementAddress.getLastPairValue());
     }
 }


### PR DESCRIPTION
This is useful as address points to resource in management API tree and
the last item is the resource name, which this way can be easily
retrieved.