### PR TITLE
Support for generate-self-signed-certificate-host

### DIFF
--- a/commands/src/main/resources/org/wildfly/extras/creaper/commands/security/realms/AddSslServerIdentity.groovy
+++ b/commands/src/main/resources/org/wildfly/extras/creaper/commands/security/realms/AddSslServerIdentity.groovy
@@ -16,6 +16,7 @@ if (keystorePath != null) keystoreAttrs['path'] = keystorePath
 if (keystoreProvider != null) keystoreAttrs['provider'] = keystoreProvider
 if (keystoreRelativeTo != null) keystoreAttrs['relative-to'] = keystoreRelativeTo
 if (protocol != null) keystoreAttrs['protocol'] = protocol
+if (generateSelfSignedCertHost) keystoreAttrs['generate-self-signed-certificate-host'] = generateSelfSignedCertHost
 
 def sslDefinition = {
     'ssl' {

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/security/realms/AddSslServerIdentityOfflineTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/security/realms/AddSslServerIdentityOfflineTest.java
@@ -20,7 +20,7 @@ import static org.wildfly.extras.creaper.XmlAssert.assertXmlIdentical;
 public class AddSslServerIdentityOfflineTest {
 
     private static final String REALM_EMPTY = ""
-            + "<server xmlns=\"urn:jboss:domain:1.7\">\n"
+            + "<server xmlns=\"urn:jboss:domain:4.2\">\n"
             + "    <management>\n"
             + "        <security-realms>\n"
             + "            <security-realm name=\"realmName\"/>\n"
@@ -28,24 +28,33 @@ public class AddSslServerIdentityOfflineTest {
             + "    </management>\n"
             + "</server>";
 
-    private static final String REALM_WITH_SSL = ""
-            + "<server xmlns=\"urn:jboss:domain:1.7\">\n"
-            + "    <management>\n"
-            + "        <security-realms>\n"
-            + "            <security-realm name=\"realmName\">\n"
-            + "                <server-identities>\n"
-            + "                    <ssl>\n"
-            + "                       <engine enabled-cipher-suites=\"DEFAULT ALL\" enabled-protocols=\"SSL TLS\"/>\n"
-            + "                       <keystore path=\"server.keystore\" relative-to=\"jboss.server.config.dir\" "
-            + "                                 keystore-password=\"password\" key-password=\"password\""
-            + "                                 alias=\"alias\" provider=\"JKS\" protocol=\"TLS\""
-            + "                                 />\n"
-            + "                    </ssl>\n"
-            + "                </server-identities>\n"
-            + "            </security-realm>\n"
-            + "        </security-realms>\n"
-            + "    </management>\n"
-            + "</server>";
+    private static final String REALM_WITH_SSL = realmWithSsl("");
+    private static final String REALM_WITH_SSL_AND_GENERATE_SELF_SIGNED_CERT =
+            realmWithSsl("generate-self-signed-certificate-host=\"localhost\"");
+
+
+    private static String realmWithSsl(String sslKeystoreAdditionalParams) {
+        return ""
+                + "<server xmlns=\"urn:jboss:domain:4.2\">\n"
+                + "    <management>\n"
+                + "        <security-realms>\n"
+                + "            <security-realm name=\"realmName\">\n"
+                + "                <server-identities>\n"
+                + "                    <ssl>\n"
+                + "                       <engine enabled-cipher-suites=\"DEFAULT ALL\" enabled-protocols=\"SSL TLS\"/>\n"
+                + "                       <keystore path=\"server.keystore\" relative-to=\"jboss.server.config.dir\" "
+                + "                                 keystore-password=\"password\" key-password=\"password\""
+                + "                                 alias=\"alias\" provider=\"JKS\" protocol=\"TLS\" "
+                + sslKeystoreAdditionalParams
+                + "                                 />\n"
+                + "                    </ssl>\n"
+                + "                </server-identities>\n"
+                + "            </security-realm>\n"
+                + "        </security-realms>\n"
+                + "    </management>\n"
+                + "</server>";
+    }
+
 
     private static final String PASSWORD = "password";
 
@@ -148,5 +157,32 @@ public class AddSslServerIdentityOfflineTest {
         client.apply(cmd1);
         client.apply(cmd2);
         assertXmlIdentical(REALM_WITH_SSL, Files.toString(cfg, Charsets.UTF_8));
+    }
+
+    @Test
+    public void addWithGenerateSelfSignedCert() throws Exception {
+        File cfg = tmp.newFile("xmlTransform.xml");
+        Files.write(REALM_EMPTY, cfg, Charsets.UTF_8);
+
+        OfflineManagementClient client = ManagementClient.offline(
+                OfflineOptions.standalone().configurationFile(cfg).build());
+
+        AddSslServerIdentity cmd = new AddSslServerIdentity.Builder("realmName")
+                .alias("alias")
+                .keystorePath("server.keystore")
+                .keystorePassword("password")
+                .keyPassword("password")
+                .keystoreProvider("JKS")
+                .protocol("TLS")
+                .keystoreRelativeTo("jboss.server.config.dir")
+                .cipherSuitesToEnable("DEFAULT", "ALL")
+                .protocolsToEnable("SSL", "TLS")
+                .generateSelfSignedCertHost("localhost")
+                .build();
+
+        assertXmlIdentical(REALM_EMPTY, Files.toString(cfg, Charsets.UTF_8));
+        client.apply(cmd);
+        System.out.println(Files.toString(cfg, Charsets.UTF_8));
+        assertXmlIdentical(REALM_WITH_SSL_AND_GENERATE_SELF_SIGNED_CERT, Files.toString(cfg, Charsets.UTF_8));
     }
 }


### PR DESCRIPTION
Since WildFly 10.1 there exist new option
generate-self-signed-certificate-host as part of ssl definition of
security realm. Added support and for older versions of server ignoring
its value.