### PR TITLE
urn:wildfly check in SubsystemSubtreeLocator

### DIFF
--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/Subtree.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/Subtree.java
@@ -213,8 +213,10 @@ public final class Subtree {
     }
 
     private static final class SubsystemSubtreeLocator implements SubtreeLocator {
-        private static final Class STANDALONE_OR_HOST_SCRIPT_CLASS = GroovyHolder.GROOVY.parseClass("root.profile.subsystem.find { it.@xmlns.toString().startsWith(\"urn:jboss:domain:${subsystemName}:\") }");
-        private static final Class DOMAIN_SCRIPT_CLASS = GroovyHolder.GROOVY.parseClass("root.profiles.profile.find { it.@name == defaultProfile }.subsystem.find { it.@xmlns.toString().startsWith(\"urn:jboss:domain:${subsystemName}:\") }");
+        private static final Class STANDALONE_OR_HOST_SCRIPT_CLASS = GroovyHolder.GROOVY.parseClass("root.profile.subsystem.find { it.@xmlns.toString()"
+                + ".startsWith(\"urn:jboss:domain:${subsystemName}:\") || it.@xmlns.toString().startsWith(\"urn:wildfly:${subsystemName}:\")} ");
+        private static final Class DOMAIN_SCRIPT_CLASS = GroovyHolder.GROOVY.parseClass("root.profiles.profile.find { it.@name == defaultProfile }.subsystem"
+                + ".find { it.@xmlns.toString().startsWith(\"urn:jboss:domain:${subsystemName}:\") || it.@xmlns.toString().startsWith(\"urn:wildfly:${subsystemName}:\") }");
 
         private final String subsystemName;
 


### PR DESCRIPTION
urn:wildfly check in SubsystemSubtreeLocator, needed for new subsystems like elytron

I think https://github.com/jboss-security-qe/creaper/commit/5e02e4303982dd440ebe6ae594037a9573763916 can't be back-ported as is. It mixes commands and core infrastructure enhancements (e.g. this change).
