### PR TITLE
Log creaper commands in JSON format in debug

### DIFF
--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineManagementClientImpl.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineManagementClientImpl.java
@@ -149,7 +149,8 @@ final class OnlineManagementClientImpl implements OnlineManagementClient {
     public ModelNodeResult execute(ModelNode operation) throws IOException {
         checkClosed();
         operation = adjustOperationForDomain.adjust(operation);
-        log.debugf("Executing operation %s", ModelNodeOperationToCliString.convert(operation));
+        log.debugf("Executing operation %s\nJSON format:\n%s", ModelNodeOperationToCliString.convert(operation),
+                operation.toJSONString(false));
         ModelNode result = client.execute(operation);
         return new ModelNodeResult(result);
     }


### PR DESCRIPTION
Resolves #151 

It producelog output as:
INFO: Executing operation /core-service=management/security-realm=creaperSecRealm:add
JSON format:
{
    "operation" : "add",
    "address" : [
        {
            "core-service" : "management"
        },
        {
            "security-realm" : "creaperSecRealm"
        }
    ]
}