### PR TITLE
Use explicit location in tests which use AddCredentialStore

### DIFF
--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/elytron/credentialstore/AddCredentialStoreAliasOnlineTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/elytron/credentialstore/AddCredentialStoreAliasOnlineTest.java
@@ -3,23 +3,17 @@ package org.wildfly.extras.creaper.commands.elytron.credentialstore;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.commands.elytron.CredentialRef;
 import org.wildfly.extras.creaper.core.CommandFailedException;
-import org.wildfly.extras.creaper.core.online.OnlineCommand;
-import org.wildfly.extras.creaper.core.online.OnlineCommandContext;
-import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.Address;
-import org.wildfly.extras.creaper.core.online.operations.Operations;
-import org.wildfly.extras.creaper.core.online.operations.Values;
 
 @RunWith(Arquillian.class)
 public class AddCredentialStoreAliasOnlineTest extends AbstractCredentialStoreOnlineTest {
@@ -31,36 +25,17 @@ public class AddCredentialStoreAliasOnlineTest extends AbstractCredentialStoreOn
     private static final String TEST_CREDENTIAL_STORE_ALIAS_NAME = "creapertestcredentialstorealias";
     private static final String TEST_CREDENTIAL_STORE_ALIAS_NAME2 = "creapertestcredentialstorealias2";
 
-    private static final String PATH = "path";
-    private static final String TMP = "tmp";
-    private static final Address TEST_PATH_TMP_ADDRESS = Address.root()
-            .and(PATH, TMP);
-
     @ClassRule
     public static TemporaryFolder tmp = new TemporaryFolder();
-
-    @BeforeClass
-    public static void createTmpPath() throws Exception {
-        OnlineManagementClient client = null;
-        try {
-            client = createManagementClient();
-            AddTmpDirectoryToPath addTargetToPath = new AddTmpDirectoryToPath();
-            client.apply(addTargetToPath);
-        } finally {
-            if (client != null) {
-                client.close();
-            }
-        }
-    }
 
     @Before
     public void createCredentialStore() throws Exception {
         AddCredentialStore addCredentialStore = new AddCredentialStore.Builder(TEST_CREDENTIAL_STORE_NAME)
                 .create(true)
+                .location(tmp.getRoot().getAbsolutePath() + File.pathSeparator + "someLocationFile")
                 .credentialReference(new CredentialRef.CredentialRefBuilder()
                         .clearText("somePassword")
                         .build())
-                .relativeTo("tmp")
                 .build();
 
         client.apply(addCredentialStore);
@@ -70,20 +45,6 @@ public class AddCredentialStoreAliasOnlineTest extends AbstractCredentialStoreOn
     public void cleanup() throws Exception {
         ops.removeIfExists(TEST_CREDENTIAL_STORE_ADDRESS);
         administration.reloadIfRequired();
-    }
-
-    @AfterClass
-    public static void removeTmpPath() throws Exception {
-        OnlineManagementClient client = null;
-        try {
-            client = createManagementClient();
-            Operations operations = new Operations(client);
-            operations.removeIfExists(TEST_PATH_TMP_ADDRESS);
-        } finally {
-            if (client != null) {
-                client.close();
-            }
-        }
     }
 
     @Test
@@ -242,16 +203,4 @@ public class AddCredentialStoreAliasOnlineTest extends AbstractCredentialStoreOn
         fail("Creating command with empty secret-value should throw exception");
     }
 
-    private static final class AddTmpDirectoryToPath implements OnlineCommand {
-
-        @Override
-        public void apply(OnlineCommandContext ctx) throws Exception {
-            Operations ops = new Operations(ctx.client);
-            Address pathAddress = Address.root()
-                    .and(PATH, TMP);
-
-            ops.add(pathAddress, Values.empty()
-                    .and(PATH, tmp.getRoot().getAbsolutePath()));
-        }
-    }
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/elytron/credentialstore/RemoveCredentialStoreOnlineTest.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/extras/creaper/commands/elytron/credentialstore/RemoveCredentialStoreOnlineTest.java
@@ -4,9 +4,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.commands.elytron.AbstractElytronOnlineTest;
 import org.wildfly.extras.creaper.commands.elytron.CredentialRef;
@@ -20,6 +23,9 @@ public class RemoveCredentialStoreOnlineTest extends AbstractElytronOnlineTest {
     private static final Address TEST_CREDENTIAL_STORE_ADDRESS = SUBSYSTEM_ADDRESS
             .and("credential-store", TEST_CREDENTIAL_STORE_NAME);
 
+    @ClassRule
+    public static TemporaryFolder tmp = new TemporaryFolder();
+
     @After
     public void cleanup() throws Exception {
         ops.removeIfExists(TEST_CREDENTIAL_STORE_ADDRESS);
@@ -30,6 +36,7 @@ public class RemoveCredentialStoreOnlineTest extends AbstractElytronOnlineTest {
     public void removeCredentialStore() throws Exception {
         AddCredentialStore addCredentialStore = new AddCredentialStore.Builder(TEST_CREDENTIAL_STORE_NAME)
                 .create(true)
+                .location(tmp.getRoot().getAbsolutePath() + File.pathSeparator + "someLocationFile")
                 .credentialReference(new CredentialRef.CredentialRefBuilder()
                         .clearText("somePassword")
                         .build())


### PR DESCRIPTION
Since WFLY 13 location for AddCredentialStore is required when JCEKS type is used. In previous version WildFly is able to use some magic and generate location with name derived from resource name. However for Creaper command test purposes it is safer to use some named location.