### PR TITLE
Added ServerVersion for Wildfly 13

### DIFF
--- a/core/src/main/java/org/wildfly/extras/creaper/core/ServerVersion.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/ServerVersion.java
@@ -72,6 +72,8 @@ public final class ServerVersion {
     public static final ServerVersion VERSION_5_0_0 = new ServerVersion(5, 0, 0);
     /** WF 12.0.0.Final */
     public static final ServerVersion VERSION_6_0_0 = new ServerVersion(6, 0, 0);
+    /** WF 13 (not yet final) */
+    public static final ServerVersion VERSION_7_0_0 = new ServerVersion(7, 0, 0);
 
     private static final ServerVersion[] KNOWN_VERSIONS = {
             VERSION_0_0_0,
@@ -93,6 +95,7 @@ public final class ServerVersion {
             VERSION_4_2_0,
             VERSION_5_0_0,
             VERSION_6_0_0,
+            VERSION_7_0_0,
     };
 
     /**

--- a/core/src/test/java/org/wildfly/extras/creaper/core/ServerVersionTest.java
+++ b/core/src/test/java/org/wildfly/extras/creaper/core/ServerVersionTest.java
@@ -30,6 +30,7 @@ public class ServerVersionTest {
         assertSame(ServerVersion.VERSION_4_2_0, ServerVersion.from(4, 2, 0));
         assertSame(ServerVersion.VERSION_5_0_0, ServerVersion.from(5, 0, 0));
         assertSame(ServerVersion.VERSION_6_0_0, ServerVersion.from(6, 0, 0));
+        assertSame(ServerVersion.VERSION_7_0_0, ServerVersion.from(7, 0, 0));
 
         assertNotSame(ServerVersion.from(42, 42, 42), ServerVersion.from(42, 42, 42));
     }
@@ -55,6 +56,7 @@ public class ServerVersionTest {
         assertEquals(ServerVersion.VERSION_4_2_0, ServerVersion.from(4, 2, 0));
         assertEquals(ServerVersion.VERSION_5_0_0, ServerVersion.from(5, 0, 0));
         assertEquals(ServerVersion.VERSION_6_0_0, ServerVersion.from(6, 0, 0));
+        assertEquals(ServerVersion.VERSION_7_0_0, ServerVersion.from(7, 0, 0));
 
         assertEquals(ServerVersion.from(42, 42, 42), ServerVersion.from(42, 42, 42));
     }

--- a/core/src/test/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersionTest.java
+++ b/core/src/test/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersionTest.java
@@ -49,6 +49,7 @@ public class OfflineServerVersionTest {
     private static final String EAP7_EE = "4.0";
 
     private static final String WFLY12_ROOT = "6.0";
+    private static final String WFLY13_ROOT = "7.0";
 
     @Rule
     public final TemporaryFolder tmp = new TemporaryFolder();
@@ -99,6 +100,11 @@ public class OfflineServerVersionTest {
     }
 
     @Test
+    public void discoverStandaloneXml_wfly13() throws IOException {
+        test(ServerVersion.VERSION_7_0_0, STANDALONE_XML, WFLY13_ROOT, EAP7_LOGGING, EAP7_EE);
+    }
+
+    @Test
     public void discoverHostXml_eap6() throws IOException {
         test(ServerVersion.VERSION_1_7_0, HOST_XML, EAP6_ROOT, EAP6_LOGGING, EAP6_EE);
     }
@@ -119,6 +125,11 @@ public class OfflineServerVersionTest {
     }
 
     @Test
+    public void discoverHostXml_wfly13() throws IOException {
+        test(ServerVersion.VERSION_7_0_0, HOST_XML, WFLY13_ROOT, EAP7_LOGGING, EAP7_EE);
+    }
+
+    @Test
     public void discoverDomainXml_eap6() throws IOException {
         test(ServerVersion.VERSION_1_7_0, DOMAIN_XML, EAP6_ROOT, EAP6_LOGGING, EAP6_EE);
     }
@@ -136,6 +147,11 @@ public class OfflineServerVersionTest {
     @Test
     public void discoverDomainXml_wfly12() throws IOException {
         test(ServerVersion.VERSION_6_0_0, DOMAIN_XML, WFLY12_ROOT, EAP7_LOGGING, EAP7_EE);
+    }
+
+    @Test
+    public void discoverDomainXml_wfly13() throws IOException {
+        test(ServerVersion.VERSION_7_0_0, DOMAIN_XML, WFLY13_ROOT, EAP7_LOGGING, EAP7_EE);
     }
 
     private void test(ServerVersion expected, String xmlPattern,


### PR DESCRIPTION
Added ServerVersion VERSION_7_0_0 (WF 13 which is not released yet) to allow WF 13 commands development. Profile wildfly13 in testsuite will be added later when wildfly13 will be released.