### PR TITLE
move build to JDK 1.8, support JDK11

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -100,7 +100,6 @@
             <property name="tokens" value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE"/>
         </module>
         <module name="LeftCurly">
-            <property name="maxLineLength" value="120"/>
 <!--
             <property name="ignoreEnums" value="false"/>
 -->

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/auditlog/AddAuditLogSyslogHandler.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/auditlog/AddAuditLogSyslogHandler.java
@@ -203,7 +203,7 @@ public final class AddAuditLogSyslogHandler implements OnlineCommand, OfflineCom
         protected String host;
         protected Integer port;
 
-        public AbstractBuilder(String name) {
+        AbstractBuilder(String name) {
             if (name == null) {
                 throw new IllegalArgumentException("Syslog handler name must be specified as non null value");
             }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/auth/PropertiesFileAuth.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/auth/PropertiesFileAuth.java
@@ -170,7 +170,7 @@ public final class PropertiesFileAuth {
         private final String roleOrGroup;
         private final boolean trueToAdd_falseToRemove;
 
-        public AbstractUserMapping(String username, String roleOrGroup, boolean trueToAdd_falseToRemove) {
+        AbstractUserMapping(String username, String roleOrGroup, boolean trueToAdd_falseToRemove) {
             this.username = username;
             this.roleOrGroup = roleOrGroup;
             this.trueToAdd_falseToRemove = trueToAdd_falseToRemove;

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/datasources/AddJdbcDriver.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/datasources/AddJdbcDriver.java
@@ -69,8 +69,7 @@ public final class AddJdbcDriver implements OnlineCommand, OfflineCommand {
     /**
      * Builder for configuration attributes of a JDBC driver in the {@code datasources} susbystem.
      *
-     * @see <a href="http://wildscribe.github.io/JBoss EAP/6.2.0/subsystem/datasources/jdbc-driver/">
-     *        http://wildscribe.github.io/JBoss EAP/6.2.0/subsystem/datasources/jdbc-driver/</a>
+     * @see <a href="http://wildscribe.github.io/JBoss%20EAP/6.2.0/subsystem/datasources/jdbc-driver/">http://wildscribe.github.io/JBoss EAP/6.2.0/subsystem/datasources/jdbc-driver/</a>
      */
     public static final class Builder {
         private String driverName;

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/datasources/AddMariaDbDataSource.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/datasources/AddMariaDbDataSource.java
@@ -11,7 +11,7 @@ import static org.wildfly.extras.creaper.commands.datasources.DatasourceConstant
  *
  * <p>Connection URL format is expected to be: {@code jdbc:mariadb://localhost:3306/database-name}</p>
  *
- * <p>Applies defaults of datasource settings used for testing JBoss EAP 7.<br/>
+ * <p>Applies defaults of datasource settings used for testing JBoss EAP 7.<br>
  * Note: classes of connection checker or exception sorter are the same as for MySQL datasource.
  * </p>
  */

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/datasources/AddMariaDbXADataSource.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/datasources/AddMariaDbXADataSource.java
@@ -18,7 +18,7 @@ import static org.wildfly.extras.creaper.commands.datasources.DatasourceConstant
  *     <li>{@code DatabaseName}</li>
  * </ul>
  *
- * <p>Applies defaults from testing JBoss EAP 7.<br/>
+ * <p>Applies defaults from testing JBoss EAP 7.<br>
  * Note: classes for connection checker and exception sorter are the same as for MySQL datasource</p>
  */
 public final class AddMariaDbXADataSource extends AddXADataSource {

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/datasources/AddMariaDbXADataSource.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/datasources/AddMariaDbXADataSource.java
@@ -8,6 +8,7 @@ import static org.wildfly.extras.creaper.commands.datasources.DatasourceConstant
 import static org.wildfly.extras.creaper.commands.datasources.DatasourceConstants.MARIADB_XA_DATASOURCE_CLASS;
 import static org.wildfly.extras.creaper.commands.datasources.DatasourceConstants.MYSQL_EXCEPTION_SORTER;
 import static org.wildfly.extras.creaper.commands.datasources.DatasourceConstants.MYSQL_VALID_CONNECTION_CHECKER;
+
 /**
  * Creates a Maria DB XA datasource.
  *
@@ -22,6 +23,7 @@ import static org.wildfly.extras.creaper.commands.datasources.DatasourceConstant
  * Note: classes for connection checker and exception sorter are the same as for MySQL datasource</p>
  */
 public final class AddMariaDbXADataSource extends AddXADataSource {
+
     AddMariaDbXADataSource(Builder builder) {
         super(builder);
     }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/deployments/Deploy.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/deployments/Deploy.java
@@ -22,7 +22,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENA
 
 /**
  * Command which takes care about deploying specified deployment under specified deployment name.
- * <p/>
+ * <br>
  * In case of domain it is deployed by default to all server groups
  */
 public final class Deploy implements OnlineCommand {

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/deployments/Undeploy.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/deployments/Undeploy.java
@@ -40,7 +40,7 @@ public final class Undeploy implements OnlineCommand {
         }
 
         /**
-         * Defines that the content should be left in the deployment repository => only undeployed without removing it.
+         * Defines that the content should be left in the deployment repository =&gt; only undeployed without removing it.
          */
         public Builder keepContent() {
             this.keepContent = true;

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/deployments/Undeploy.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/deployments/Undeploy.java
@@ -40,7 +40,8 @@ public final class Undeploy implements OnlineCommand {
         }
 
         /**
-         * Defines that the content should be left in the deployment repository =&gt; only undeployed without removing it.
+         * Defines that the content should be left in the deployment
+         * repository =&gt; only undeployed without removing it.
          */
         public Builder keepContent() {
             this.keepContent = true;

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/audit/AddSyslogAuditLog.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/audit/AddSyslogAuditLog.java
@@ -124,7 +124,7 @@ public final class AddSyslogAuditLog implements OnlineCommand {
 
     }
 
-    public static enum TransportProtocolType {
+    public enum TransportProtocolType {
 
         UDP, TCP;
     }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/authenticationclient/AddAuthenticationConfiguration.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/authenticationclient/AddAuthenticationConfiguration.java
@@ -225,7 +225,7 @@ public final class AddAuthenticationConfiguration implements OnlineCommand {
 
     }
 
-    public static enum ForwardingMode {
+    public enum ForwardingMode {
 
         AUTHENTICATION, AUTHORIZATION
     }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/credentialstore/AddCredentialStoreAlias.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/credentialstore/AddCredentialStoreAlias.java
@@ -114,13 +114,13 @@ public final class AddCredentialStoreAlias implements OnlineCommand {
         }
     }
 
-    public static enum EntryType {
+    public enum EntryType {
 
         OTHER("Other"), PASSWORD_CREDENTIAL("org.wildfly.security.credential.PasswordCredential");
 
         private final String entryTypeName;
 
-        private EntryType(String entryTypeName) {
+        EntryType(String entryTypeName) {
             this.entryTypeName = entryTypeName;
         }
 

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/dircontext/AddDirContext.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/dircontext/AddDirContext.java
@@ -196,12 +196,12 @@ public final class AddDirContext implements OnlineCommand {
         }
     }
 
-    public static enum AuthenticationLevel {
+    public enum AuthenticationLevel {
 
         NONE, SIMPLE, STRONG
     }
 
-    public static enum ReferralMode {
+    public enum ReferralMode {
 
         FOLLOW, IGNORE, THROW
     }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AbstractAddPrincipalDecoder.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AbstractAddPrincipalDecoder.java
@@ -23,7 +23,7 @@ abstract class AbstractAddPrincipalDecoder implements OnlineCommand {
         protected final List<String> principalDecoders = new ArrayList<String>();
         private boolean replaceExisting;
 
-        public Builder(String name) {
+        Builder(String name) {
             if (name == null) {
                 throw new IllegalArgumentException("Name of the aggregate-principal-decoder must be specified as non null value");
             }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AbstractAddPrincipalTransformer.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AbstractAddPrincipalTransformer.java
@@ -22,7 +22,7 @@ abstract class AbstractAddPrincipalTransformer implements OnlineCommand {
         protected final List<String> principalTransformers = new ArrayList<String>();
         private boolean replaceExisting;
 
-        public Builder(String name) {
+        Builder(String name) {
             if (name == null) {
                 throw new IllegalArgumentException("Name of the name-decoder must be specified as non null value");
             }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AddLogicalPermissionMapper.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AddLogicalPermissionMapper.java
@@ -95,7 +95,7 @@ public final class AddLogicalPermissionMapper implements OnlineCommand {
         }
     }
 
-    public static enum LogicalOperation {
+    public enum LogicalOperation {
 
         AND, UNLESS, OR, XOR
     }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AddLogicalRoleMapper.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AddLogicalRoleMapper.java
@@ -90,7 +90,7 @@ public final class AddLogicalRoleMapper implements OnlineCommand {
 
     }
 
-    public static enum LogicalOperation {
+    public enum LogicalOperation {
 
         AND, MINUS, OR, XOR
     }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AddSimplePermissionMapper.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/mapper/AddSimplePermissionMapper.java
@@ -279,7 +279,7 @@ public final class AddSimplePermissionMapper implements OnlineCommand {
         }
     }
 
-    public static enum MappingMode {
+    public enum MappingMode {
 
         AND, FIRST, OR, UNLESS, XOR
     }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/sasl/AddMechanismProviderFilteringSaslServerFactory.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/sasl/AddMechanismProviderFilteringSaslServerFactory.java
@@ -186,13 +186,13 @@ public final class AddMechanismProviderFilteringSaslServerFactory implements Onl
 
     }
 
-    public static enum VersionComparison {
+    public enum VersionComparison {
 
         GREATER_THAN("greater-than"), LESS_THAN("less-than");
 
         private final String versionComparisonName;
 
-        private VersionComparison(String versionComparisonName) {
+        VersionComparison(String versionComparisonName) {
             this.versionComparisonName = versionComparisonName;
         }
 

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/tls/AbstractAddSSLContext.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/elytron/tls/AbstractAddSSLContext.java
@@ -51,7 +51,7 @@ abstract class AbstractAddSSLContext implements OnlineCommand, OfflineCommand {
         protected String providers;
         protected String providerName;
 
-        public Builder(String name) {
+        Builder(String name) {
             if (name == null) {
                 throw new IllegalArgumentException("Name of the ssl-context must be specified as non null value");
             }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/Subtree.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/Subtree.java
@@ -220,7 +220,7 @@ public final class Subtree {
 
         private final String subsystemName;
 
-        public SubsystemSubtreeLocator(String subsystemName) {
+        SubsystemSubtreeLocator(String subsystemName) {
             this.subsystemName = subsystemName;
         }
 
@@ -271,7 +271,7 @@ public final class Subtree {
         private final String profileName;
         private final String subsystemName;
 
-        public SubsystemInProfileSubtreeLocator(String profileName, String subsystemName) {
+        SubsystemInProfileSubtreeLocator(String profileName, String subsystemName) {
             this.profileName = profileName;
             this.subsystemName = subsystemName;
         }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/logging/AbstractConsoleLogHandlerCommand.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/logging/AbstractConsoleLogHandlerCommand.java
@@ -16,7 +16,7 @@ abstract class AbstractConsoleLogHandlerCommand implements OnlineCommand, Offlin
     protected final LogLevel level;
     protected final ConsoleTarget target;
 
-    protected AbstractConsoleLogHandlerCommand(Builder builder) {
+    AbstractConsoleLogHandlerCommand(Builder builder) {
         this.name = builder.name;
         this.autoflush = builder.autoflush;
         this.enabled = builder.enabled;
@@ -39,7 +39,7 @@ abstract class AbstractConsoleLogHandlerCommand implements OnlineCommand, Offlin
         protected LogLevel level;
         protected ConsoleTarget target;
 
-        public Builder(String name) {
+        Builder(String name) {
             if (name == null) {
                 throw new IllegalArgumentException("Name can not be null.");
             }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/logging/AbstractLoggerCommand.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/logging/AbstractLoggerCommand.java
@@ -14,7 +14,7 @@ abstract class AbstractLoggerCommand implements OnlineCommand, OfflineCommand {
     protected final Boolean useParentHandler;
     protected final String filter;
 
-    protected AbstractLoggerCommand(Builder builder) {
+    AbstractLoggerCommand(Builder builder) {
         this.category = builder.category;
         this.level = builder.level;
         this.handlers = builder.handlers;
@@ -29,7 +29,7 @@ abstract class AbstractLoggerCommand implements OnlineCommand, OfflineCommand {
         protected Boolean useParentHandler;
         protected String filter;
 
-        public Builder(String category) {
+        Builder(String category) {
             if (category == null || category.equals("")) {
                 throw new IllegalArgumentException("category can not be null nor empty string");
             }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/logging/AbstractPeriodicRotatingFileLogHandlerCommand.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/logging/AbstractPeriodicRotatingFileLogHandlerCommand.java
@@ -19,7 +19,7 @@ abstract class AbstractPeriodicRotatingFileLogHandlerCommand implements OnlineCo
     protected final String fileRelativeTo;
     protected final String file;
 
-    protected AbstractPeriodicRotatingFileLogHandlerCommand(Builder builder) {
+    AbstractPeriodicRotatingFileLogHandlerCommand(Builder builder) {
         this.name = builder.name;
         this.autoflush = builder.autoflush;
         this.enabled = builder.enabled;
@@ -48,7 +48,7 @@ abstract class AbstractPeriodicRotatingFileLogHandlerCommand implements OnlineCo
         protected String fileRelativeTo;
         protected String file;
 
-        public Builder(String name, String file, String suffix) {
+        Builder(String name, String file, String suffix) {
             if (name == null) {
                 throw new IllegalArgumentException("name can not be null.");
             }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/modules/AddModule.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/modules/AddModule.java
@@ -26,7 +26,7 @@ import java.util.List;
  *
  * <pre>
  * module add --name=name --slot=slot --resources=jars
- *            --resource-delimiter=char --dependencies=modules --properties=properties</p>
+ *            --resource-delimiter=char --dependencies=modules --properties=properties
  * </pre>
  */
 public class AddModule implements OnlineCommand {

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/orb/ChangeOrb.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/orb/ChangeOrb.java
@@ -20,8 +20,8 @@ import org.wildfly.extras.creaper.core.online.operations.Operations;
  * Creaper command which allows settings of orb subsystem
  *
  * <ul>
- *   <li>JacORB for AS7 and WildFly <= 8</li>
- *   <li>OpenJDK IIOP ORB for WildFly >= 9</li>
+ *   <li>JacORB for AS7 and WildFly &lt;= 8</li>
+ *   <li>OpenJDK IIOP ORB for WildFly &gt;= 9</li>
  * </ul>
  */
 public final class ChangeOrb implements OfflineCommand, OnlineCommand {

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/security/realms/AbstractAddSecurityRealmSubElement.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/security/realms/AbstractAddSecurityRealmSubElement.java
@@ -30,7 +30,7 @@ abstract class AbstractAddSecurityRealmSubElement implements OnlineCommand, Offl
         private String securityRealmName;
         private boolean replaceExisting;
 
-        public Builder(String securityRealmName) {
+        Builder(String securityRealmName) {
             if (securityRealmName == null) {
                 throw new IllegalArgumentException("Name of security realm must be specified as non null value");
             }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/security/realms/AddSslServerIdentity.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/security/realms/AddSslServerIdentity.java
@@ -203,7 +203,7 @@ public class AddSslServerIdentity extends AbstractAddSecurityRealmSubElement {
          *     It will be generated only if there doesn't exist the defined keystore.
          * </p>
          * <p>
-         *     This option is available since WildFly 10.1 => for older versions it is ignored
+         *     This option is available since WildFly 10.1 =&gt; for older versions it is ignored
          * </p>
          */
         public Builder generateSelfSignedCertHost(String generateSelfSignedCertHost) {

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/undertow/AddUndertowListener.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/undertow/AddUndertowListener.java
@@ -234,7 +234,7 @@ public final class AddUndertowListener implements OnlineCommand {
          * Creates builder for listener with specified name {@code listenerName} for specified undertow server
          * {@code serverName} using specified socket binding {@code socketBinding}
          */
-        public UndertowListenerBuilder(String listenerName, String serverName, String socketBinding) {
+        UndertowListenerBuilder(String listenerName, String serverName, String socketBinding) {
             if (listenerName == null) {
                 throw new IllegalArgumentException("Name of the listener must be specified as non null value");
             }
@@ -254,7 +254,7 @@ public final class AddUndertowListener implements OnlineCommand {
          * Creates builder for listener with specified name {@code listenerName} for default undertow server
          * using specified socket binding {@code socketBinding}
          */
-        public UndertowListenerBuilder(String listenerName, String socketBinding) {
+        UndertowListenerBuilder(String listenerName, String socketBinding) {
             if (listenerName == null) {
                 throw new IllegalArgumentException("Name of the listener must be specified as non null value");
             }

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/undertow/AddUndertowListener.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/undertow/AddUndertowListener.java
@@ -612,7 +612,6 @@ public final class AddUndertowListener implements OnlineCommand {
 
         /**
          * <p>Defines which security realm should be used by the listener.</p>
-         * <p/>
          * <p>
          * Note, there is also created {@link AddHttpsSecurityRealm} allowing to easily create security realm with
          * specified name

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,6 +15,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
             <!-- only to get rid of warnings when generating JavaDoc -->
             <groupId>com.google.code.cookcc</groupId>
             <artifactId>cookcc</artifactId>

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/HttpModelControllerClient.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/HttpModelControllerClient.java
@@ -256,7 +256,7 @@ final class HttpModelControllerClient implements ModelControllerClient {
 
     private static class HttpModelControllerClientAsyncFutureTask<T> extends AsyncFutureTask<T> {
 
-        public HttpModelControllerClientAsyncFutureTask(Executor executor, T result) {
+        HttpModelControllerClientAsyncFutureTask(Executor executor, T result) {
             super(executor);
             super.setResult(result);
         }
@@ -267,7 +267,7 @@ final class HttpModelControllerClient implements ModelControllerClient {
 
         private final ModelNode modelNode;
 
-        public ModelNodeFromModelNodeCallable(ModelNode modelNode) {
+        ModelNodeFromModelNodeCallable(ModelNode modelNode) {
             this.modelNode = modelNode;
         }
 
@@ -281,7 +281,7 @@ final class HttpModelControllerClient implements ModelControllerClient {
 
         private final Operation operation;
 
-        public ModelNodeFromOperationCallable(Operation operation) {
+        ModelNodeFromOperationCallable(Operation operation) {
             this.operation = operation;
         }
 
@@ -295,7 +295,7 @@ final class HttpModelControllerClient implements ModelControllerClient {
 
         private final Operation operation;
 
-        public OperationResponseFromOperationCallable(Operation operation) {
+        OperationResponseFromOperationCallable(Operation operation) {
             this.operation = operation;
         }
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/ModelNodeResult.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/ModelNodeResult.java
@@ -266,7 +266,7 @@ public class ModelNodeResult extends ModelNode {
 
         return new Iterable<ModelNodeResult>() {
             @Override
-            public final Iterator<ModelNodeResult> iterator() {
+            public Iterator<ModelNodeResult> iterator() {
                 return new Iterator<ModelNodeResult>() {
                     private int index = 0;
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/SslOptions.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/SslOptions.java
@@ -4,6 +4,8 @@ import com.google.common.io.ByteSource;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -259,6 +261,7 @@ public final class SslOptions {
         return trustManagerFactory.getTrustManagers();
     }
 
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF") // spotbugs doesn't know guava's @Nullable
     private KeyStore createKeyStore() {
         final KeyStore keyStore = createStore(this.keyStoreType);
         InputStream keyStoreStream = null;
@@ -325,6 +328,7 @@ public final class SslOptions {
         return replacementKeyStore;
     }
 
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF") // spotbugs doesn't know guava's @Nullable
     private KeyStore createTrustStore() {
         final KeyStore trustStore = createStore(this.trustStoreType);
         InputStream trustStoreStream = null;

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/SslOptions.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/SslOptions.java
@@ -199,7 +199,7 @@ public final class SslOptions {
 
     /**
      * System properties like {@literal javax.net.ssl.keyStore} are not taken into account.
-     * See {@link http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#Customization}.
+     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#Customization">http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#Customization</a>.
      */
     SSLContext createSslContext() {
         final KeyManager[] keyManagers = this.getKeyManagers();

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/DomainAdministrationOperations.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/DomainAdministrationOperations.java
@@ -19,7 +19,7 @@ final class DomainAdministrationOperations implements AdministrationOperations {
     private final Operations ops;
     private final int timeoutInSeconds;
 
-    public DomainAdministrationOperations(OnlineManagementClient client, int timeoutInSeconds) {
+    DomainAdministrationOperations(OnlineManagementClient client, int timeoutInSeconds) {
         this.client = client;
         this.ops = new Operations(client);
         this.timeoutInSeconds = timeoutInSeconds;

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/StandaloneAdministrationOperations.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/operations/admin/StandaloneAdministrationOperations.java
@@ -16,7 +16,7 @@ final class StandaloneAdministrationOperations implements AdministrationOperatio
     private final Operations ops;
     private final int timeoutInSeconds;
 
-    public StandaloneAdministrationOperations(OnlineManagementClient client, int timeoutInSeconds) {
+    StandaloneAdministrationOperations(OnlineManagementClient client, int timeoutInSeconds) {
         this.client = client;
         this.ops = new Operations(client);
         this.timeoutInSeconds = timeoutInSeconds;

--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
         <version.org.apache.maven.plugins.maven-surefire-plugin>2.22.1</version.org.apache.maven.plugins.maven-surefire-plugin>
         <version.org.bouncycastle>1.60</version.org.bouncycastle>
         <version.org.codehaus.groovy.groovy-everything>2.5.3</version.org.codehaus.groovy.groovy-everything>
-        <version.org.codehaus.mojo.codenarc-maven-plugin>0.22-1</version.org.codehaus.mojo.codenarc-maven-plugin>
         <version.org.codehaus.mojo.findbugs-maven-plugin>2.5.5</version.org.codehaus.mojo.findbugs-maven-plugin>
         <version.org.codehaus.mojo.findbugs-maven-plugin_java8>3.0.4</version.org.codehaus.mojo.findbugs-maven-plugin_java8>
         <version.org.hamcrest.hamcrest-core>1.3</version.org.hamcrest.hamcrest-core>
@@ -411,27 +410,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>codenarc-maven-plugin</artifactId>
-                    <version>${version.org.codehaus.mojo.codenarc-maven-plugin}</version>
-                    <configuration>
-                        <sourceDirectory>${project.basedir}/src</sourceDirectory>
-                        <rulesetfiles>file:codenarc.xml</rulesetfiles>
-                        <maxPriority1Violations>0</maxPriority1Violations>
-                        <maxPriority2Violations>0</maxPriority2Violations>
-                        <maxPriority3Violations>0</maxPriority3Violations>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>codenarc</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>codenarc</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>${version.org.codehaus.mojo.findbugs-maven-plugin}</version>
                     <executions>
@@ -458,10 +436,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>codenarc-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,7 @@
         <version.org.apache.maven.plugins.maven-surefire-plugin>2.22.1</version.org.apache.maven.plugins.maven-surefire-plugin>
         <version.org.bouncycastle>1.60</version.org.bouncycastle>
         <version.org.codehaus.groovy.groovy-everything>2.5.3</version.org.codehaus.groovy.groovy-everything>
-        <version.org.codehaus.mojo.findbugs-maven-plugin>2.5.5</version.org.codehaus.mojo.findbugs-maven-plugin>
-        <version.org.codehaus.mojo.findbugs-maven-plugin_java8>3.0.4</version.org.codehaus.mojo.findbugs-maven-plugin_java8>
+        <version.com.github.spotbugs.spotbugs-maven-plugin>3.1.7</version.com.github.spotbugs.spotbugs-maven-plugin>
         <version.org.hamcrest.hamcrest-core>1.3</version.org.hamcrest.hamcrest-core>
         <version.org.jboss.arquillian>1.1.13.Final</version.org.jboss.arquillian>
         <!-- EAP 6.4.0 -->
@@ -409,9 +408,9 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>${version.org.codehaus.mojo.findbugs-maven-plugin}</version>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${version.com.github.spotbugs.spotbugs-maven-plugin}</version>
                     <executions>
                         <execution>
                             <id>find-bugs</id>
@@ -438,22 +437,19 @@
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <!-- support Java 8: use newer FindBugs plugin, switch off Javadoc's doclint -->
+        <!-- switch off Javadoc's doclint -->
         <profile>
             <id>jdk8</id>
             <activation>
                 <jdk>[1.8,)</jdk>
             </activation>
-            <properties>
-                <version.org.codehaus.mojo.findbugs-maven-plugin>${version.org.codehaus.mojo.findbugs-maven-plugin_java8}</version.org.codehaus.mojo.findbugs-maven-plugin>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -62,30 +62,31 @@
 
         <maven.jboss.ga.repository.url>https://maven.repository.redhat.com/ga/</maven.jboss.ga.repository.url>
 
-        <version.java>1.6</version.java>
+        <version.java>1.8</version.java>
 
         <!-- All versions. Keep in alphabetical order. Name format: version.${groupId}.${artifactIdOrWildcard}. -->
         <version.com.google.code.cookcc>0.3.3</version.com.google.code.cookcc>
-        <version.com.google.guava.guava>20.0</version.com.google.guava.guava>
-        <version.com.puppycrawl.tools.checkstyle>6.1.1</version.com.puppycrawl.tools.checkstyle>
+        <!-- guava 20.0 is last version compatible with JDK 1.7 -->
+        <version.com.google.guava.guava>27.0-jre</version.com.google.guava.guava>
+        <version.com.puppycrawl.tools.checkstyle>8.14</version.com.puppycrawl.tools.checkstyle>
         <version.junit.junit>4.12</version.junit.junit>
 
-        <version.org.apache.httpcomponents.httpclient>4.5.2</version.org.apache.httpcomponents.httpclient>
+        <version.org.apache.httpcomponents.httpclient>4.5.6</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.maven.plugins.maven-antrun-plugin>1.8</version.org.apache.maven.plugins.maven-antrun-plugin>
-        <version.org.apache.maven.plugins.maven-checkstyle-plugin>2.15</version.org.apache.maven.plugins.maven-checkstyle-plugin>
-        <version.org.apache.maven.plugins.maven-clean-plugin>3.0.0</version.org.apache.maven.plugins.maven-clean-plugin>
-        <version.org.apache.maven.plugins.maven-compiler-plugin>3.6.1</version.org.apache.maven.plugins.maven-compiler-plugin>
-        <version.org.apache.maven.plugins.maven-dependency-plugin>3.0.0</version.org.apache.maven.plugins.maven-dependency-plugin>
-        <version.org.apache.maven.plugins.maven-deploy-plugin>2.8.2</version.org.apache.maven.plugins.maven-deploy-plugin>
-        <version.org.apache.maven.plugins.maven-jar-plugin>3.0.2</version.org.apache.maven.plugins.maven-jar-plugin>
-        <version.org.apache.maven.plugins.maven-javadoc-plugin>2.10.4</version.org.apache.maven.plugins.maven-javadoc-plugin>
+        <version.org.apache.maven.plugins.maven-checkstyle-plugin>3.0.0</version.org.apache.maven.plugins.maven-checkstyle-plugin>
+        <version.org.apache.maven.plugins.maven-clean-plugin>3.1.0</version.org.apache.maven.plugins.maven-clean-plugin>
+        <version.org.apache.maven.plugins.maven-compiler-plugin>3.8.0</version.org.apache.maven.plugins.maven-compiler-plugin>
+        <version.org.apache.maven.plugins.maven-dependency-plugin>3.1.1</version.org.apache.maven.plugins.maven-dependency-plugin>
+        <version.org.apache.maven.plugins.maven-deploy-plugin>3.0.0-M1</version.org.apache.maven.plugins.maven-deploy-plugin>
+        <version.org.apache.maven.plugins.maven-jar-plugin>3.1.0</version.org.apache.maven.plugins.maven-jar-plugin>
+        <version.org.apache.maven.plugins.maven-javadoc-plugin>3.0.1</version.org.apache.maven.plugins.maven-javadoc-plugin>
         <version.org.apache.maven.plugins.maven-release-plugin>2.5.3</version.org.apache.maven.plugins.maven-release-plugin>
-        <version.org.apache.maven.plugins.maven-resources-plugin>3.0.2</version.org.apache.maven.plugins.maven-resources-plugin>
-        <version.org.apache.maven.plugins.maven-shade-plugin>3.0.0</version.org.apache.maven.plugins.maven-shade-plugin>
+        <version.org.apache.maven.plugins.maven-resources-plugin>3.1.0</version.org.apache.maven.plugins.maven-resources-plugin>
+        <version.org.apache.maven.plugins.maven-shade-plugin>3.2.0</version.org.apache.maven.plugins.maven-shade-plugin>
         <version.org.apache.maven.plugins.maven-source-plugin>3.0.1</version.org.apache.maven.plugins.maven-source-plugin>
-        <version.org.apache.maven.plugins.maven-surefire-plugin>2.19.1</version.org.apache.maven.plugins.maven-surefire-plugin>
-        <version.org.bouncycastle>1.55</version.org.bouncycastle>
-        <version.org.codehaus.groovy.groovy-everything>2.4.10</version.org.codehaus.groovy.groovy-everything>
+        <version.org.apache.maven.plugins.maven-surefire-plugin>2.22.1</version.org.apache.maven.plugins.maven-surefire-plugin>
+        <version.org.bouncycastle>1.60</version.org.bouncycastle>
+        <version.org.codehaus.groovy.groovy-everything>2.5.3</version.org.codehaus.groovy.groovy-everything>
         <version.org.codehaus.mojo.codenarc-maven-plugin>0.22-1</version.org.codehaus.mojo.codenarc-maven-plugin>
         <version.org.codehaus.mojo.findbugs-maven-plugin>2.5.5</version.org.codehaus.mojo.findbugs-maven-plugin>
         <version.org.codehaus.mojo.findbugs-maven-plugin_java8>3.0.4</version.org.codehaus.mojo.findbugs-maven-plugin_java8>
@@ -96,7 +97,7 @@
         <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.modules.jboss-modules>1.3.3.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
-        <version.org.mockito.mockito-core>1.10.19</version.org.mockito.mockito-core>
+        <version.org.mockito.mockito-core>2.23.0</version.org.mockito.mockito-core>
         <version.xmlunit.xmlunit>1.6</version.xmlunit.xmlunit>
     </properties>
 
@@ -115,6 +116,12 @@
             </dependency>
 
             <!-- main dependencies -->
+            <dependency>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-annotations</artifactId>
+                <version>${version.com.github.spotbugs.spotbugs-maven-plugin}</version>
+                <optional>true</optional>
+            </dependency>
             <dependency>
                 <!-- only to get rid of warnings when generating JavaDoc -->
                 <groupId>com.google.code.cookcc</groupId>


### PR DESCRIPTION
I think it's time to move to 2.0. This is mainly to start discussion. 

touches #172 and #157 

It fixes only build (mvn clean install -DskipTests), there are no changes to test suite for now. 

I tried to make version compatible with 1.6+, but due to changes mainly to checkstyle and findbugs it is very hard. 
