### PR TITLE
Update Groovy dependencies to 3.0.9

### DIFF
--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/FirstLevelXmlElementOrder.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/FirstLevelXmlElementOrder.java
@@ -3,7 +3,7 @@ package org.wildfly.extras.creaper.commands.foundation.offline.xml;
 import com.google.common.base.Function;
 import com.google.common.collect.Ordering;
 import groovy.util.Node;
-import groovy.util.XmlParser;
+import groovy.xml.XmlParser;
 import groovy.xml.XmlUtil;
 
 import java.util.Collections;

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/GroovyXmlTransform.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/GroovyXmlTransform.java
@@ -2,9 +2,9 @@ package org.wildfly.extras.creaper.commands.foundation.offline.xml;
 
 import groovy.lang.GroovyCodeSource;
 import groovy.lang.Script;
-import groovy.util.XmlSlurper;
-import groovy.util.slurpersupport.GPathResult;
+import groovy.xml.XmlSlurper;
 import groovy.xml.XmlUtil;
+import groovy.xml.slurpersupport.GPathResult;
 import org.wildfly.extras.creaper.core.CommandFailedException;
 import org.wildfly.extras.creaper.core.offline.OfflineCommand;
 import org.wildfly.extras.creaper.core.offline.OfflineCommandContext;

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/Subtree.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/foundation/offline/xml/Subtree.java
@@ -1,7 +1,7 @@
 package org.wildfly.extras.creaper.commands.foundation.offline.xml;
 
 import groovy.lang.Script;
-import groovy.util.slurpersupport.GPathResult;
+import groovy.xml.slurpersupport.GPathResult;
 import org.wildfly.extras.creaper.core.offline.OfflineOptions;
 
 /**

--- a/commands/src/main/resources/org/wildfly/extras/creaper/commands/orb/ChangeOrb.groovy
+++ b/commands/src/main/resources/org/wildfly/extras/creaper/commands/orb/ChangeOrb.groovy
@@ -1,5 +1,5 @@
 import org.wildfly.extras.creaper.commands.orb.Attribute
-import groovy.util.slurpersupport.GPathResult
+import groovy.xml.slurpersupport.GPathResult
 
 // --- HELPER METHODS
 java.util.LinkedHashMap.metaClass.fill = { GPathResult initPath, String attrName, Attribute attrToSet ->

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <version.org.apache.maven.plugins.maven-source-plugin>3.2.1</version.org.apache.maven.plugins.maven-source-plugin>
         <version.org.apache.maven.plugins.maven-surefire-plugin>3.0.0-M5</version.org.apache.maven.plugins.maven-surefire-plugin>
         <version.org.bouncycastle>1.67</version.org.bouncycastle>
-        <version.org.codehaus.groovy.groovy-everything>2.4.21</version.org.codehaus.groovy.groovy-everything>
+        <version.org.codehaus.groovy.groovy-everything>3.0.9</version.org.codehaus.groovy.groovy-everything>
         <version.org.codehaus.mojo.codenarc-maven-plugin>0.22-1</version.org.codehaus.mojo.codenarc-maven-plugin>
         <version.com.github.spotbugs.spotbugs-maven-plugin>4.4.1</version.com.github.spotbugs.spotbugs-maven-plugin>
         <version.org.hamcrest.hamcrest-core>1.3</version.org.hamcrest.hamcrest-core>


### PR DESCRIPTION
Following https://groovy-lang.org/releasenotes/groovy-3.0.html there are some package movements but if I looked correctly, that shouldn't affect public APIs of creaper itself.

Users that are excluding groovy dependencies coming from creaper might need to update groovy dependency in their projects, though. https://github.com/wildfly-extras/creaper#transitive-dependencies 