### PR TITLE
[fix deps] Fix used dependencies for WildFly.

### DIFF
--- a/commands/pom.xml
+++ b/commands/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-patching</artifactId>
         </dependency>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,16 +23,16 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.as</groupId>
-            <artifactId>jboss-as-controller-client</artifactId>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.as</groupId>
-            <artifactId>jboss-as-cli</artifactId>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-cli</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-logging</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,10 +94,9 @@
         <version.com.github.spotbugs.spotbugs-maven-plugin>4.4.1</version.com.github.spotbugs.spotbugs-maven-plugin>
         <version.org.hamcrest.hamcrest-core>1.3</version.org.hamcrest.hamcrest-core>
         <version.org.jboss.arquillian>1.1.13.Final</version.org.jboss.arquillian>
-        <!-- EAP 6.4.0 -->
-        <version.org.jboss.as.jboss-as-everything>7.5.0.Final-redhat-21</version.org.jboss.as.jboss-as-everything>
-        <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.modules.jboss-modules>1.3.3.Final</version.org.jboss.modules.jboss-modules>
+        <!-- EAP 7.0.0 (WildFly 10) -->
+        <version.org.wildfly.core.wildfly-everything>2.0.10.Final</version.org.wildfly.core.wildfly-everything>
+        <version.org.jboss.modules.jboss-modules>1.5.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <version.org.mockito.mockito-core>1.10.19</version.org.mockito.mockito-core>
         <version.xmlunit.xmlunit>1.6</version.xmlunit.xmlunit>
@@ -140,21 +139,21 @@
                 <version>${version.org.codehaus.groovy.groovy-everything}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.as</groupId>
-                <artifactId>jboss-as-controller-client</artifactId>
-                <version>${version.org.jboss.as.jboss-as-everything}</version>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-controller-client</artifactId>
+                <version>${version.org.wildfly.core.wildfly-everything}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.jboss.as</groupId>
-                <artifactId>jboss-as-cli</artifactId>
-                <version>${version.org.jboss.as.jboss-as-everything}</version>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-cli</artifactId>
+                <version>${version.org.wildfly.core.wildfly-everything}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging}</version>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-logging</artifactId>
+                <version>${version.org.wildfly.core.wildfly-everything}</version>
             </dependency>
             <!--
               - Somehow a dependency on a non-existing version of JBoss Modules creeps into the testsuite.
@@ -167,9 +166,9 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-patching</artifactId>
-                <version>${version.org.jboss.as.jboss-as-everything}</version>
+                <version>${version.org.wildfly.core.wildfly-everything}</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
Since we now support only WildFly 10+ (JBoss EAP 7.0.0+) and dropped
everything before, we also need to align relevant dependencies where
some have moved from `org.jboss.*` namespace to `org.wildfly.*`. With
that also the version updates/alignment is necessary too.