### PR TITLE
add remote+http and remote+https protocols, deprecate old variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2.0.0 (not yet released)
 
-- switch default protocol to `http-remoting`
+- switch default protocol to `http-remoting` (still default in WildFly 10)
 - switch default port to 9990
+- add `remote+http` and `remote+https` protocols, deprecated `http-remoting` and `https-remoting`
 - drop `creaper.wildfly` property
 - drop `remoting` protocol support
 

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/ManagementProtocol.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/ManagementProtocol.java
@@ -1,10 +1,31 @@
 package org.wildfly.extras.creaper.core.online;
 
 public enum ManagementProtocol {
-    /** Used in WildFly. Default port 9990. */
+
+    /**
+     * Used in WildFly. Default port 9990.
+     * @deprecated use @{code REMOTE_HTTP} for WildFly 11 and above
+     */
+    @Deprecated
     HTTP_REMOTING("http-remoting"),
-    /** Used in WildFly. Default port 9993. */
+
+    /**
+     * Used in WildFly, supported since WildFly 11. Default port 9990.
+     */
+    REMOTE_HTTP("remote+http"),
+
+    /**
+     * Used in WildFly. Default port 9993.
+     * @deprecated use @{code REMOTE_HTTPS} for WildFly 11 and above
+     */
+    @Deprecated
     HTTPS_REMOTING("https-remoting"),
+
+    /**
+     * Used in WildFly, supported since WildFly 11. Default port 9993.
+     */
+    REMOTE_HTTPS("remote+https"),
+
     /**
      * With {@code HTTP}, the management client will not use the native management protocol,
      * but will instead use the HTTP management endpoint. The {@code ModelNode}s will be serialized to JSON. Operation

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
@@ -59,7 +59,8 @@ public final class OnlineOptions {
 
         if (data.localDefault) {
             data.host = "localhost";
-            if (data.protocol == ManagementProtocol.HTTPS_REMOTING || data.protocol == ManagementProtocol.HTTPS) {
+            if (data.protocol == ManagementProtocol.HTTPS_REMOTING || data.protocol == ManagementProtocol.REMOTE_HTTPS
+                    || data.protocol == ManagementProtocol.HTTPS) {
                 data.port = 9993;
             } else {
                 data.port = 9990;
@@ -82,8 +83,8 @@ public final class OnlineOptions {
         this.wrappedModelControllerClient = data.wrappedModelControllerClient;
         this.isWrappedClient = data.wrappedModelControllerClient != null;
 
-        if ((protocol == ManagementProtocol.HTTPS || protocol == ManagementProtocol.HTTPS_REMOTING)
-                && sslOptions == null) {
+        if ((protocol == ManagementProtocol.HTTPS || protocol == ManagementProtocol.HTTPS_REMOTING
+                || protocol == ManagementProtocol.REMOTE_HTTPS) && sslOptions == null) {
             throw new IllegalArgumentException("SSL must be configured when HTTPS or HTTPS_REMOTING protocol is used!");
         }
     }


### PR DESCRIPTION
new names are supported since WildFly 11, see https://issues.redhat.com/browse/WFCORE-296

Let's not change the default protocol, new protocols aren't supported with WildFly 10. EAP 7.0.0 is based on WildFly 10 and I would like Creaper to stay EAP 7.x compatible for now. 

But I have run tests locally with default changed to REMOTE+HTTP and all passed. 