### PR TITLE
bring back `remote` protocol

### DIFF
--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/ManagementProtocol.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/ManagementProtocol.java
@@ -2,6 +2,9 @@ package org.wildfly.extras.creaper.core.online;
 
 public enum ManagementProtocol {
 
+    /** Default port 9999. */
+    REMOTE("remote"),
+
     /**
      * Used in WildFly. Default port 9990.
      * @deprecated use @{code REMOTE_HTTP} for WildFly 11 and above

--- a/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/online/OnlineOptions.java
@@ -59,11 +59,17 @@ public final class OnlineOptions {
 
         if (data.localDefault) {
             data.host = "localhost";
-            if (data.protocol == ManagementProtocol.HTTPS_REMOTING || data.protocol == ManagementProtocol.REMOTE_HTTPS
-                    || data.protocol == ManagementProtocol.HTTPS) {
-                data.port = 9993;
-            } else {
-                data.port = 9990;
+            switch (data.protocol) {
+                case REMOTE:
+                    data.port = 9999;
+                    break;
+                case HTTPS_REMOTING:
+                case REMOTE_HTTPS:
+                case HTTPS:
+                    data.port = 9993;
+                    break;
+                default:
+                    data.port = 9990;
             }
         }
 


### PR DESCRIPTION
I was too eager to remove `remote` protocol. It is still in WildFly, working with native interface.