### PR TITLE
update maven plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,25 +74,25 @@
 
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.maven.plugins.maven-antrun-plugin>3.1.0</version.org.apache.maven.plugins.maven-antrun-plugin>
-        <version.org.apache.maven.plugins.maven-checkstyle-plugin>3.1.2</version.org.apache.maven.plugins.maven-checkstyle-plugin>
-        <version.org.apache.maven.plugins.maven-clean-plugin>3.1.0</version.org.apache.maven.plugins.maven-clean-plugin>
-        <version.org.apache.maven.plugins.maven-compiler-plugin>3.10.0</version.org.apache.maven.plugins.maven-compiler-plugin>
-        <version.org.apache.maven.plugins.maven-dependency-plugin>3.2.0</version.org.apache.maven.plugins.maven-dependency-plugin>
-        <version.org.apache.maven.plugins.maven-deploy-plugin>3.0.0-M2</version.org.apache.maven.plugins.maven-deploy-plugin>
-        <version.org.apache.maven.plugins.maven-enforcer-plugin>3.1.0</version.org.apache.maven.plugins.maven-enforcer-plugin>
-        <version.org.apache.maven.plugins.maven-install-plugin>3.0.0-M1</version.org.apache.maven.plugins.maven-install-plugin>
-        <version.org.apache.maven.plugins.maven-jar-plugin>3.2.2</version.org.apache.maven.plugins.maven-jar-plugin>
-        <version.org.apache.maven.plugins.maven-javadoc-plugin>3.4.0</version.org.apache.maven.plugins.maven-javadoc-plugin>
-        <version.org.apache.maven.plugins.maven-release-plugin>3.0.0-M6</version.org.apache.maven.plugins.maven-release-plugin>
-        <version.org.apache.maven.plugins.maven-resources-plugin>3.2.0</version.org.apache.maven.plugins.maven-resources-plugin>
-        <version.org.apache.maven.plugins.maven-shade-plugin>3.3.0</version.org.apache.maven.plugins.maven-shade-plugin>
-        <version.org.apache.maven.plugins.maven-site-plugin>3.11.0</version.org.apache.maven.plugins.maven-site-plugin>
-        <version.org.apache.maven.plugins.maven-source-plugin>3.2.1</version.org.apache.maven.plugins.maven-source-plugin>
-        <version.org.apache.maven.plugins.maven-surefire-plugin>3.0.0-M7</version.org.apache.maven.plugins.maven-surefire-plugin>
+        <version.org.apache.maven.plugins.maven-checkstyle-plugin>3.3.0</version.org.apache.maven.plugins.maven-checkstyle-plugin>
+        <version.org.apache.maven.plugins.maven-clean-plugin>3.3.1</version.org.apache.maven.plugins.maven-clean-plugin>
+        <version.org.apache.maven.plugins.maven-compiler-plugin>3.11.0</version.org.apache.maven.plugins.maven-compiler-plugin>
+        <version.org.apache.maven.plugins.maven-dependency-plugin>3.6.0</version.org.apache.maven.plugins.maven-dependency-plugin>
+        <version.org.apache.maven.plugins.maven-deploy-plugin>3.1.1</version.org.apache.maven.plugins.maven-deploy-plugin>
+        <version.org.apache.maven.plugins.maven-enforcer-plugin>3.3.0</version.org.apache.maven.plugins.maven-enforcer-plugin>
+        <version.org.apache.maven.plugins.maven-install-plugin>3.1.1</version.org.apache.maven.plugins.maven-install-plugin>
+        <version.org.apache.maven.plugins.maven-jar-plugin>3.3.0</version.org.apache.maven.plugins.maven-jar-plugin>
+        <version.org.apache.maven.plugins.maven-javadoc-plugin>3.5.0</version.org.apache.maven.plugins.maven-javadoc-plugin>
+        <version.org.apache.maven.plugins.maven-release-plugin>3.0.1</version.org.apache.maven.plugins.maven-release-plugin>
+        <version.org.apache.maven.plugins.maven-resources-plugin>3.3.1</version.org.apache.maven.plugins.maven-resources-plugin>
+        <version.org.apache.maven.plugins.maven-shade-plugin>3.5.0</version.org.apache.maven.plugins.maven-shade-plugin>
+        <version.org.apache.maven.plugins.maven-site-plugin>4.0.0-M8</version.org.apache.maven.plugins.maven-site-plugin>
+        <version.org.apache.maven.plugins.maven-source-plugin>3.3.0</version.org.apache.maven.plugins.maven-source-plugin>
+        <version.org.apache.maven.plugins.maven-surefire-plugin>3.1.2</version.org.apache.maven.plugins.maven-surefire-plugin>
         <version.org.bouncycastle>1.71</version.org.bouncycastle>
         <version.org.codehaus.groovy.groovy-everything>3.0.9</version.org.codehaus.groovy.groovy-everything>
         <version.org.codehaus.mojo.codenarc-maven-plugin>0.22-1</version.org.codehaus.mojo.codenarc-maven-plugin>
-        <version.com.github.spotbugs.spotbugs-maven-plugin>4.7.0.0</version.com.github.spotbugs.spotbugs-maven-plugin>
+        <version.com.github.spotbugs.spotbugs-maven-plugin>4.7.3.5</version.com.github.spotbugs.spotbugs-maven-plugin>
         <version.org.hamcrest.hamcrest-core>2.2</version.org.hamcrest.hamcrest-core>
         <version.org.jboss.arquillian>1.6.0.Final</version.org.jboss.arquillian>
         <!-- EAP 7.0.0 (WildFly 10) -->


### PR DESCRIPTION
to get rid of most of maven validation warnings

remaining are
```
[WARNING] 
[WARNING] Plugin validation issues were detected in 2 plugin(s)
[WARNING] 
[WARNING]  * org.apache.maven.plugins:maven-checkstyle-plugin:3.3.0
[WARNING]   Declared at location(s):
[WARNING]    * org.wildfly.extras.creaper:creaper-parent:2.0.3-SNAPSHOT (pom.xml) @ line 458
[WARNING]   Used in module(s):
[WARNING]    * org.wildfly.extras.creaper:creaper-parent:2.0.3-SNAPSHOT (pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-core:2.0.3-SNAPSHOT (core/pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-commands:2.0.3-SNAPSHOT (commands/pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-testsuite:2.0.3-SNAPSHOT (testsuite/pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-testsuite-common:2.0.3-SNAPSHOT (testsuite/common/pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-testsuite-standalone:2.0.3-SNAPSHOT (testsuite/standalone/pom.xml)
[WARNING]   Mojo issue(s):
[WARNING]    * Mojo checkstyle:checkstyle (org.apache.maven.plugins.checkstyle.CheckstyleReport)
[WARNING]      - Parameter 'localRepository' uses deprecated parameter expression '${localRepository}': ArtifactRepository type is deprecated and its use in Mojos should be avoided.
[WARNING] 
[WARNING]  * org.apache.maven.plugins:maven-javadoc-plugin:3.5.0
[WARNING]   Declared at location(s):
[WARNING]    * org.wildfly.extras.creaper:creaper-parent:2.0.3-SNAPSHOT (pom.xml) @ line 462
[WARNING]   Used in module(s):
[WARNING]    * org.wildfly.extras.creaper:creaper-parent:2.0.3-SNAPSHOT (pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-core:2.0.3-SNAPSHOT (core/pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-commands:2.0.3-SNAPSHOT (commands/pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-testsuite:2.0.3-SNAPSHOT (testsuite/pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-testsuite-common:2.0.3-SNAPSHOT (testsuite/common/pom.xml)
[WARNING]    * org.wildfly.extras.creaper:creaper-testsuite-standalone:2.0.3-SNAPSHOT (testsuite/standalone/pom.xml)
[WARNING]   Plugin issue(s):
[WARNING]    * Plugin depends on plexus-container-default, which is EOL
```