### PR TITLE
Resolves#236 Update the namespace detection for the root namespace to support stability level qualifiers.

### DIFF
--- a/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersion.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersion.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 final class OfflineServerVersion {
 
     /*
-     * The namespaces in WildFly may also contain an optional Stabilty qualifier e.g.
+     * The namespaces in WildFly may also contain an optional Stability qualifier e.g.
      *
      *     urn:jboss:domain:community:21.0
      *

--- a/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersion.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersion.java
@@ -17,7 +17,7 @@ final class OfflineServerVersion {
      *     urn:jboss:domain:community:21.0
      *
      * Within the regular expression "(?:community:|preview:|experimental:)?":
-     *  - This it a non capturing group to avoid changing the index of the versions.
+     *  - This is a non capturing group to avoid changing the index of the versions.
      *  - The group is optional so can appear 0 or 1 times.
      *  - As the stability qualifier appears in the same space as some subsystem names
      *    the allowed qualifiers are specified.

--- a/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersion.java
+++ b/core/src/main/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersion.java
@@ -10,7 +10,20 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 final class OfflineServerVersion {
-    private static final Pattern ROOT_XMLNS = Pattern.compile("[\"']urn:jboss:domain:(\\d+)\\.(\\d+)[\"']");
+
+    /*
+     * The namespaces in WildFly may also contain an optional Stabilty qualifier e.g.
+     *
+     *     urn:jboss:domain:community:21.0
+     *
+     * Within the regular expression "(?:community:|preview:|experimental:)?":
+     *  - This it a non capturing group to avoid changing the index of the versions.
+     *  - The group is optional so can appear 0 or 1 times.
+     *  - As the stability qualifier appears in the same space as some subsystem names
+     *    the allowed qualifiers are specified.
+     */
+
+    private static final Pattern ROOT_XMLNS = Pattern.compile("[\"']urn:jboss:domain:(?:community:|preview:|experimental:)?(\\d+)\\.(\\d+)[\"']");
 
     private OfflineServerVersion() {
         // avoid instantiation

--- a/core/src/test/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersionTest.java
+++ b/core/src/test/java/org/wildfly/extras/creaper/core/offline/OfflineServerVersionTest.java
@@ -68,6 +68,10 @@ public class OfflineServerVersionTest {
     private static final String WFLY27_ROOT = "20.0";
     private static final String WFLY28_ROOT = "21.0";
 
+    private static final String COMMUNITY = "community";
+    private static final String PREVIEW = "preview";
+    private static final String EXPERIMENTAL = "experimental";
+
     @Rule
     public final TemporaryFolder tmp = new TemporaryFolder();
 
@@ -197,6 +201,23 @@ public class OfflineServerVersionTest {
     }
 
     @Test
+    public void discoverStandaloneXml_wfly34_community() throws IOException {
+        test(ServerVersion.VERSION_20_0_0, STANDALONE_XML, COMMUNITY,  WFLY27_ROOT, EAP7_LOGGING, EAP8_EE);
+    }
+
+    @Test
+    public void discoverStandaloneXml_wfly34_experimental() throws IOException {
+        // Doesn't currently exist but verify it can be parsed correctly.
+        test(ServerVersion.VERSION_20_0_0, STANDALONE_XML, EXPERIMENTAL,  WFLY27_ROOT, EAP7_LOGGING, EAP8_EE);
+    }
+
+    @Test
+    public void discoverStandaloneXml_wfly34_preview() throws IOException {
+        // Doesn't currently exist but verify it can be parsed correctly.
+        test(ServerVersion.VERSION_20_0_0, STANDALONE_XML, PREVIEW,  WFLY27_ROOT, EAP7_LOGGING, EAP8_EE);
+    }
+
+    @Test
     public void discoverHostXml_eap6() throws IOException {
         test(ServerVersion.VERSION_1_7_0, HOST_XML, EAP6_ROOT, EAP6_LOGGING, EAP6_EE);
     }
@@ -294,6 +315,23 @@ public class OfflineServerVersionTest {
     @Test
     public void discoverHostXml_wfly28() throws IOException {
         test(ServerVersion.VERSION_21_0_0, HOST_XML, WFLY28_ROOT, EAP7_LOGGING, EAP8_EE);
+    }
+
+    @Test
+    public void discoverHostXml_wfly34_community() throws IOException {
+        test(ServerVersion.VERSION_20_0_0, HOST_XML, COMMUNITY, WFLY27_ROOT, EAP7_LOGGING, EAP8_EE);
+    }
+
+    @Test
+    public void discoverHostXml_wfly34_preview() throws IOException {
+        // Doesn't currently exist but verify it can be parsed correctly.
+        test(ServerVersion.VERSION_20_0_0, HOST_XML, PREVIEW, WFLY27_ROOT, EAP7_LOGGING, EAP8_EE);
+    }
+
+    @Test
+    public void discoverHostXml_wfly34_experimental() throws IOException {
+        // Doesn't currently exist but verify it can be parsed correctly.
+        test(ServerVersion.VERSION_20_0_0, HOST_XML, EXPERIMENTAL, WFLY27_ROOT, EAP7_LOGGING, EAP8_EE);
     }
 
     @Test
@@ -396,10 +434,33 @@ public class OfflineServerVersionTest {
         test(ServerVersion.VERSION_21_0_0, DOMAIN_XML, WFLY28_ROOT, EAP7_LOGGING, EAP8_EE);
     }
 
+    @Test
+    public void discoverDomainXml_wfly34_community() throws IOException {
+        test(ServerVersion.VERSION_20_0_0, DOMAIN_XML, COMMUNITY, WFLY27_ROOT, EAP7_LOGGING, EAP8_EE);
+    }
+
+    @Test
+    public void discoverDomainXml_wfly34_preview() throws IOException {
+        // Doesn't currently exist but verify it can be parsed correctly.
+        test(ServerVersion.VERSION_20_0_0, DOMAIN_XML, PREVIEW, WFLY27_ROOT, EAP7_LOGGING, EAP8_EE);
+    }
+
+    @Test
+    public void discoverDomainXml_wfly34_experimental() throws IOException {
+        // Doesn't currently exist but verify it can be parsed correctly.
+        test(ServerVersion.VERSION_20_0_0, DOMAIN_XML, EXPERIMENTAL, WFLY27_ROOT, EAP7_LOGGING, EAP8_EE);
+    }
+
     private void test(ServerVersion expected, String xmlPattern,
                       String rootVersion, String loggingVersion, String eeVersion) throws IOException {
+        test(expected, xmlPattern, null, rootVersion, loggingVersion, eeVersion);
+    }
+
+    private void test(ServerVersion expected, String xmlPattern, String stability,
+                      String rootVersion, String loggingVersion, String eeVersion) throws IOException {
+        String version = stability == null ? rootVersion : stability + ":" + rootVersion;
         String xml = xmlPattern
-                .replace("%ROOT_VERSION%", rootVersion)
+                .replace("%ROOT_VERSION%", version)
                 .replace("%LOGGING_VERSION%", loggingVersion)
                 .replace("%EE_VERSION%", eeVersion);
 


### PR DESCRIPTION
Within the regular expression I did first try an extra segment of lowercase alpha characters followed by the colon but that is where I saw we had an overlap with the namespaces of some of our early subsystems so instead specify the known qualifiers.

Although they are not all in use at the moment and which one is present by default will change over time I added tests for all stability levels to check they can all be parsed correctly.
