### PR TITLE
Add support for JDK 21

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
       fail-fast: false
     name: Non-elytron tests on JDK ${{ matrix.java }} - default WildFly profile
     steps:
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
       fail-fast: false
     name: Elytron tests on JDK ${{ matrix.java }} - default WildFly profile
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.0.3 (not yet released)
 
 - added support for WildFly 28 - 30
+- upgraded groovy to 4.0.22
+- added JDK 21 CI
 
 ## 2.0.2 (2023-01-18)
 

--- a/commands/pom.xml
+++ b/commands/pom.xml
@@ -30,11 +30,11 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-xml</artifactId>
         </dependency>
 

--- a/commands/src/main/java/org/wildfly/extras/creaper/commands/orb/Attribute.java
+++ b/commands/src/main/java/org/wildfly/extras/creaper/commands/orb/Attribute.java
@@ -10,7 +10,7 @@ package org.wildfly.extras.creaper.commands.orb;
  *   <li>undefined value - current value will be undefined</li>
  * </ul>
  */
-final class Attribute<T> {
+public final class Attribute<T> {
     private final T value;
     private final boolean isToUndefine;
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <version.com.puppycrawl.tools.checkstyle>9.3</version.com.puppycrawl.tools.checkstyle>
         <version.junit.junit>4.13.2</version.junit.junit>
 
+        <version.org.apache.groovy.groovy-everything>4.0.22</version.org.apache.groovy.groovy-everything>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.maven.plugins.maven-antrun-plugin>3.1.0</version.org.apache.maven.plugins.maven-antrun-plugin>
         <version.org.apache.maven.plugins.maven-checkstyle-plugin>3.3.0</version.org.apache.maven.plugins.maven-checkstyle-plugin>
@@ -90,7 +91,6 @@
         <version.org.apache.maven.plugins.maven-source-plugin>3.3.0</version.org.apache.maven.plugins.maven-source-plugin>
         <version.org.apache.maven.plugins.maven-surefire-plugin>3.1.2</version.org.apache.maven.plugins.maven-surefire-plugin>
         <version.org.bouncycastle>1.74</version.org.bouncycastle>
-        <version.org.codehaus.groovy.groovy-everything>3.0.9</version.org.codehaus.groovy.groovy-everything>
         <version.org.codehaus.mojo.codenarc-maven-plugin>0.22-1</version.org.codehaus.mojo.codenarc-maven-plugin>
         <version.com.github.spotbugs.spotbugs-maven-plugin>4.7.3.5</version.com.github.spotbugs.spotbugs-maven-plugin>
         <version.org.hamcrest.hamcrest-core>2.2</version.org.hamcrest.hamcrest-core>
@@ -131,14 +131,14 @@
                 <version>${version.org.apache.httpcomponents.httpclient}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy</artifactId>
-                <version>${version.org.codehaus.groovy.groovy-everything}</version>
+                <version>${version.org.apache.groovy.groovy-everything}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-xml</artifactId>
-                <version>${version.org.codehaus.groovy.groovy-everything}</version>
+                <version>${version.org.apache.groovy.groovy-everything}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.core</groupId>


### PR DESCRIPTION
- Groovy only supports java 21 from 4.0.11+ (it also changed groupId), updated it to the latest 4.0.22
- With the groovy update, there seems to be some change regarding the accessibility of package-private classes. (org.wildfly.extras.creaper.commands.orb.Attribute changed to public)
- Added JDK 21 to the Github actions