### PR TITLE
[#244] drop explicit dependency on jboss-logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 2.0.4 (not yet released)
+## 2.1.0 (not yet released)
+
+- dropped explicit dependency on `jboss-logging`
 
 ## 2.0.3 (2024-09-16)
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ __You have to provide both `*-controller-client` and `*-cli` yourself.__
 If you want to use commands for patching, you also have to provide
 `wildfly-patching`.
 
+You might need to tweak other dependencies to transitively bring
+compatible `jboss-logging` from `wildfly-core` or explicitly provide
+compatible version. WildFly 34 and newer requires at least `3.6.0`.
+
 Other dependencies might be required if you're using "local" CLI operations,
 such as `jms-queue add ...` on WildFly 10 (it was a built-in operation
 in previous WildFly versions, but was moved to a separate module due to
@@ -641,7 +645,6 @@ on Creaper:
 
 - `creaper-core`:
     - `com.google.guava:guava`
-    - `org.jboss.logging:jboss-logging`
 - `creaper-commands`:
     - everything from `creaper-core`
     - `org.codehaus.groovy:groovy`

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,10 +31,6 @@
             <artifactId>wildfly-cli</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
         <version.org.jboss.arquillian>1.6.0.Final</version.org.jboss.arquillian>
         <!-- EAP 7.0.0 (WildFly 10) -->
         <version.org.wildfly.core.wildfly-everything>2.2.0.Final</version.org.wildfly.core.wildfly-everything>
-        <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.modules.jboss-modules>2.0.3.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <version.org.mockito.mockito-core>4.6.1</version.org.mockito.mockito-core>
@@ -151,11 +150,6 @@
                 <artifactId>wildfly-cli</artifactId>
                 <version>${version.org.wildfly.core.wildfly-everything}</version>
                 <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging}</version>
             </dependency>
             <!--
               - Somehow a dependency on a non-existing version of JBoss Modules creeps into the testsuite.


### PR DESCRIPTION
fixes https://github.com/wildfly-extras/creaper/issues/244

*this is candidate for minor Creaper version bump to 2.1*

It attempts to fix issue due to current dependecy situation:
* creaper has explicit dependency on jboss-logging 3.3.0.Final
* jboss-logging added new methods in 3.6.0
* wildfly-core uses new methods from jboss-logging 3.6.x since 26.0.0.Beta3 which means WildFly 34
* it results in #244

Let's bring in jboss-logging transitivitely from wildfly-core to keep version aligned.

----

Originally jboss-logging dependency was added with this commit message

```
OnlineManagementClient and OfflineManagementClient now log all commands
and operations they are performing. Operations (online only) are logged
on the DEBUG level, commands are logged on INFO. Also, commands are now
advised to provide a toString() method that is used for logging.

The logging framework that is used in Creaper is JBoss Logging, because:

1. It is not actually a logging framework, it's only a facade that delegates
   the logging work to some logging framework that appears to be used.
2. It can detect all commonly used logging frameworks (Logback, Log4j, JUL)
   and one uncommon too (JBoss LogManager).
3. Creaper already depended on it transitively. Avoiding new dependencies
   is good.
4. It has a really small and nice API.
```